### PR TITLE
feat: implement comment entity and infrastructure of insert comment

### DIFF
--- a/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
@@ -1,0 +1,10 @@
+package com.depromeet.coquality.inner.comment.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Comment {
+    private String contents;
+    private Long userId;
+    private Long postId;
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
@@ -1,4 +1,7 @@
 package com.depromeet.coquality.inner.comment.port.driven;
 
+import com.depromeet.coquality.inner.comment.domain.Comment;
+
 public interface CommentPort {
+    void insert(final Comment comment);
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.outer.comment.adapter.driven.persistence;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
+import com.depromeet.coquality.outer.comment.entity.CommentEntity;
+import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaCommentAdapter implements CommentPort {
+    private final JpaCommentRepository jpaCommentRepository;
+
+    public JpaCommentAdapter(JpaCommentRepository jpaCommentRepository) {
+        this.jpaCommentRepository = jpaCommentRepository;
+    }
+
+    @Override
+    public void insert(Comment comment) {
+        jpaCommentRepository.save(
+                CommentEntity.factory()
+                        .contents(comment.getContents())
+                        .userId(comment.getUserId())
+                        .postId(comment.getPostId())
+                        .newInstance()
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -4,15 +4,13 @@ import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
 import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class JpaCommentAdapter implements CommentPort {
     private final JpaCommentRepository jpaCommentRepository;
-
-    public JpaCommentAdapter(JpaCommentRepository jpaCommentRepository) {
-        this.jpaCommentRepository = jpaCommentRepository;
-    }
 
     @Override
     public void insert(Comment comment) {

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -1,0 +1,46 @@
+package com.depromeet.coquality.outer.comment.entity;
+
+import com.depromeet.coquality.outer.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = CommentEntity.TABLE_NAME)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CommentEntity extends BaseEntity {
+    public static final String TABLE_NAME = "comments";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 200)
+    private String contents;
+
+    // TODO, mapped when userEntity is ready
+    private Long userId;
+
+    // TODO, mapped when postEntity is ready
+    private Long postId;
+
+    private final LocalDateTime deletedAt = null;
+
+    @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
+    private CommentEntity(Long id, String contents, Long userId, Long postId) {
+        this.id = id;
+        this.contents = contents;
+        this.userId = userId;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
 
@@ -21,10 +18,6 @@ import java.time.LocalDateTime;
 public class CommentEntity extends BaseEntity {
     public static final String TABLE_NAME = "comments";
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @Column(length = 200)
     private String contents;
 
@@ -34,13 +27,13 @@ public class CommentEntity extends BaseEntity {
     // TODO, mapped when postEntity is ready
     private Long postId;
 
-    private final LocalDateTime deletedAt = null;
+    private LocalDateTime deletedAt;
 
     @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
     private CommentEntity(Long id, String contents, Long userId, Long postId) {
-        this.id = id;
         this.contents = contents;
         this.userId = userId;
         this.postId = postId;
+        this.deletedAt = null;
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/infrastructure/JpaCommentRepository.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/infrastructure/JpaCommentRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.coquality.outer.comment.infrastructure;
+
+import com.depromeet.coquality.outer.comment.entity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCommentRepository extends JpaRepository<CommentEntity, Long> {
+}

--- a/src/main/java/com/depromeet/coquality/outer/common/entity/BaseEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/entity/BaseEntity.java
@@ -5,12 +5,19 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @MappedSuperclass
 @Getter
-public class BaseEntity {
+public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/depromeet/coquality/outer/common/entity/BaseEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/entity/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.depromeet.coquality.outer.common.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 개요
close #4 

## 작업사항
- 임시 댓글 엔티티를 구현했어요.
<img width="895" alt="Screen Shot 2022-11-05 at 16 28 01" src="https://user-images.githubusercontent.com/48412963/200108205-97beaf8d-1b0f-4e29-9918-8d9401e09f63.png">

- 댓글이 삽입되는 인프라 로직을 구현했어요.

- API 및 서비스 레이어는 추후에 다른 이슈로 구현할게요!

## 변경로직
- timestamp를 담은 BaseEntity를 구현해뒀어요.
