### PR TITLE
feat: oauth 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,16 @@ dependencies {
     // swagger
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+    //open feign
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.4"
+    }
 }

--- a/src/main/java/com/depromeet/coquality/inner/common/util/HttpHeaderUtils.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/util/HttpHeaderUtils.java
@@ -1,0 +1,13 @@
+package com.depromeet.coquality.inner.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HttpHeaderUtils {
+    private static final String BEARER_TOKEN = "Bearer ";
+
+    public static String withBearerToken(String token) {
+        return BEARER_TOKEN.concat(token);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
@@ -15,16 +15,16 @@ import java.util.Map;
 public class SignUpUserProvider {
     private static final Map<UserSocialType, SignUpUserUseCase> signUserServiceMap = new HashMap<>();
 
-    private final KaKaoSignUpService kaKaoAuthService;
+    private final KaKaoSignUpService kaKaoSignUpService;
     //TODO 애플, 구글 확장 고려
-//    private final AppleAuthService appleAuthService;
-//    private final GoogleAuthService googleAuthService;
+//    private final AppleAuthService appleSignUpService;
+//    private final GoogleAuthService googleSignUpService;
 
     @PostConstruct
     void initializeAuthServicesMap() {
-        signUserServiceMap.put(UserSocialType.KAKAO, kaKaoAuthService);
-//        authServiceMap.put(UserSocialType.APPLE, appleAuthService);
-//        authServiceMap.put(UserSocialType.GOOGLE, googleAuthService);
+        signUserServiceMap.put(UserSocialType.KAKAO, kaKaoSignUpService);
+//        authServiceMap.put(UserSocialType.APPLE, appleSignUpService);
+//        authServiceMap.put(UserSocialType.GOOGLE, googleSignUpService);
     }
     public SignUpUserUseCase getSignUpService(final UserSocialType socialType) {
         return signUserServiceMap.get(socialType);

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Component
 public class SignUpUserProvider {
-    private static final Map<UserSocialType, SignUpUserUseCase> signUserServiceMap = new HashMap<>();
+    private final Map<UserSocialType, SignUpUserUseCase> signUserServiceMap = new HashMap<>();
 
     private final KaKaoSignUpService kaKaoSignUpService;
     //TODO 애플, 구글 확장 고려

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
@@ -26,7 +26,7 @@ public class SignUpUserProvider {
 //        authServiceMap.put(UserSocialType.APPLE, appleAuthService);
 //        authServiceMap.put(UserSocialType.GOOGLE, googleAuthService);
     }
-    public SignUpUserUseCase getSignUpService(UserSocialType socialType) {
+    public SignUpUserUseCase getSignUpService(final UserSocialType socialType) {
         return signUserServiceMap.get(socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignUpUserProvider.java
@@ -1,0 +1,32 @@
+package com.depromeet.coquality.inner.user.apllication.service;
+
+import com.depromeet.coquality.inner.user.apllication.service.kakao.KaKaoSignUpService;
+import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class SignUpUserProvider {
+    private static final Map<UserSocialType, SignUpUserUseCase> signUserServiceMap = new HashMap<>();
+
+    private final KaKaoSignUpService kaKaoAuthService;
+    //TODO 애플, 구글 확장 고려
+//    private final AppleAuthService appleAuthService;
+//    private final GoogleAuthService googleAuthService;
+
+    @PostConstruct
+    void initializeAuthServicesMap() {
+        signUserServiceMap.put(UserSocialType.KAKAO, kaKaoAuthService);
+//        authServiceMap.put(UserSocialType.APPLE, appleAuthService);
+//        authServiceMap.put(UserSocialType.GOOGLE, googleAuthService);
+    }
+    public SignUpUserUseCase getSignUpService(UserSocialType socialType) {
+        return signUserServiceMap.get(socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.inner.user.apllication.service.kakao;
+
+import com.depromeet.coquality.inner.common.util.HttpHeaderUtils;
+import com.depromeet.coquality.inner.user.domain.User;
+import com.depromeet.coquality.inner.user.port.driven.UserPort;
+import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
+import com.depromeet.coquality.inner.user.port.driving.dto.request.SignUpDto;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import com.depromeet.coquality.outer.user.external.client.kakao.KaKaoAuthApiClient;
+import com.depromeet.coquality.outer.user.external.client.kakao.dto.response.KaKaoProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KaKaoSignUpService implements SignUpUserUseCase {
+
+    private static final UserSocialType socialType = UserSocialType.KAKAO;
+    private final UserPort userPort;
+    private final KaKaoAuthApiClient kakaoAuthApiCaller;
+
+    @Override
+    public Long execute(final SignUpDto request) {
+        final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
+        return userPort.insert(User.of(response.getId(), response.getAccount().getEmail(), String.valueOf(socialType)));
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
@@ -24,6 +24,6 @@ public class KaKaoSignUpService implements SignUpUserUseCase {
     @Override
     public Long execute(final SignUpDto request) {
         final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
-        return userPort.insert(User.of(response.getId(), response.getAccount().getEmail(), String.valueOf(socialType)));
+        return userPort.insert(User.of(response.getId(), response.getAccount().getEmail()), socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
@@ -1,6 +1,7 @@
 package com.depromeet.coquality.inner.user.apllication.service.kakao;
 
 import com.depromeet.coquality.inner.common.util.HttpHeaderUtils;
+import com.depromeet.coquality.inner.user.apllication.service.utils.SignUpUserServiceUtils;
 import com.depromeet.coquality.inner.user.domain.User;
 import com.depromeet.coquality.inner.user.port.driven.UserPort;
 import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
@@ -20,10 +21,12 @@ public class KaKaoSignUpService implements SignUpUserUseCase {
     private static final UserSocialType socialType = UserSocialType.KAKAO;
     private final UserPort userPort;
     private final KaKaoAuthApiClient kakaoAuthApiCaller;
+    private final SignUpUserServiceUtils signUpUserServiceUtils;
 
     @Override
     public Long execute(final SignUpDto request) {
         final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
+        signUpUserServiceUtils.validateNotExistsUser(response.getId(), socialType);
         return userPort.insert(User.of(response.getId(), response.getAccount().getEmail()), socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
@@ -10,9 +10,11 @@ import com.depromeet.coquality.outer.user.external.client.kakao.KaKaoAuthApiClie
 import com.depromeet.coquality.outer.user.external.client.kakao.dto.response.KaKaoProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @RequiredArgsConstructor
+@Transactional
+@Service
 public class KaKaoSignUpService implements SignUpUserUseCase {
 
     private static final UserSocialType socialType = UserSocialType.KAKAO;

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/utils/SignUpUserServiceUtils.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/utils/SignUpUserServiceUtils.java
@@ -1,0 +1,22 @@
+package com.depromeet.coquality.inner.user.apllication.service.utils;
+
+import com.depromeet.coquality.outer.user.entity.UserEntity;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class SignUpUserServiceUtils {
+    private final JpaUserRepository jpaUserRepository;
+
+    public void validateNotExistsUser(final String socialId, final UserSocialType socialType) {
+        final Optional<UserEntity> existUser = jpaUserRepository.existsBySocialIdAndSocialType(socialId, socialType);
+        if (existUser.isPresent()){
+            throw new IllegalArgumentException(String.format("이미 존재하는 유저 (%s - %s) 입니다", socialId, socialType));
+        }
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.depromeet.coquality.inner.user.domain;
 
+import com.depromeet.coquality.inner.user.domain.policy.validation.UserValidationPolicy;
 import lombok.Getter;
 
 @Getter
@@ -7,14 +8,13 @@ public class User {
     private String nickname;
     private String socialId;
     private String socialEmail;
-    private String socialType;
 
-    private User(final String socialId, final String socialEmail, final String socialType) {
+    private User(final String socialId, final String socialEmail) {
         this.socialId = socialId;
         this.socialEmail = socialEmail;
-        this.socialType = socialType;
+        UserValidationPolicy.validate(this);
     }
-    public static User of(final String socialId, final String socialEmail, final String socialType){
-        return new User(socialId, socialEmail, socialType);
+    public static User of(final String socialId, final String socialEmail){
+        return new User(socialId, socialEmail);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
@@ -1,0 +1,20 @@
+package com.depromeet.coquality.inner.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public class User {
+    private String nickname;
+    private String socialId;
+    private String socialEmail;
+    private String socialType;
+
+    private User(final String socialId, final String socialEmail, final String socialType) {
+        this.socialId = socialId;
+        this.socialEmail = socialEmail;
+        this.socialType = socialType;
+    }
+    public static User of(final String socialId, final String socialEmail, final String socialType){
+        return new User(socialId, socialEmail, socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/domain/policy/validation/UserValidationPolicy.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/domain/policy/validation/UserValidationPolicy.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.inner.user.domain.policy.validation;
+
+import com.depromeet.coquality.inner.user.domain.User;
+
+public final class UserValidationPolicy {
+
+    private UserValidationPolicy() {
+    }
+
+    public static void validate(final User user) {
+        validateSocialId(user.getSocialId());
+        validateSocialEmail(user.getSocialEmail());
+    }
+
+    //TODO exception 정리 필요
+    private static void validateSocialEmail(final String socialEmail) {
+        if (socialEmail == null){
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static void validateSocialId(final String socialId) {
+        if (socialId == null){
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
@@ -2,9 +2,10 @@ package com.depromeet.coquality.inner.user.port.driven;
 
 
 import com.depromeet.coquality.inner.user.domain.User;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
 
 public interface UserPort {
-    Long insert(User user);
+    Long insert(User user, UserSocialType socialType);
 
     void delete(final Long id);
 

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
@@ -1,11 +1,10 @@
 package com.depromeet.coquality.inner.user.port.driven;
 
-import com.depromeet.coquality.inner.post.domain.Post;
+
+import com.depromeet.coquality.inner.user.domain.User;
 
 public interface UserPort {
-    void insert();
-
-    Post fetch(final Long id);
+    Long insert(User user);
 
     void delete(final Long id);
 

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/SignUpUserUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/SignUpUserUseCase.java
@@ -1,5 +1,8 @@
 package com.depromeet.coquality.inner.user.port.driving;
 
+
+import com.depromeet.coquality.inner.user.port.driving.dto.request.SignUpDto;
+
 public interface SignUpUserUseCase {
-    void execute();
+    Long execute(SignUpDto signUpDto);
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
@@ -1,0 +1,22 @@
+package com.depromeet.coquality.inner.user.port.driving.dto.request;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignUpDto {
+    private String token;
+    private String socialType;
+
+    private SignUpDto(final String token, final String socialType) {
+        this.token = token;
+        this.socialType = socialType;
+    }
+
+    public static SignUpDto of(String token, String socialType) {
+        return new SignUpDto(token, socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
@@ -1,12 +1,9 @@
 package com.depromeet.coquality.inner.user.port.driving.dto.request;
 
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignUpDto {
     private String token;
     private String socialType;
@@ -16,7 +13,7 @@ public class SignUpDto {
         this.socialType = socialType;
     }
 
-    public static SignUpDto of(String token, String socialType) {
+    public static SignUpDto of(final String token, final String socialType) {
         return new SignUpDto(token, socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -1,0 +1,39 @@
+package com.depromeet.coquality.outer.user.adapter.driven.persistance;
+
+import com.depromeet.coquality.inner.user.domain.User;
+import com.depromeet.coquality.inner.user.port.driven.UserPort;
+import com.depromeet.coquality.outer.user.entity.UserEntity;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaUserAdapter implements UserPort {
+
+    private final JpaUserRepository jpaUserRepository;
+
+
+    @Override
+    public Long insert(final User user) {
+        final UserEntity saveUser = jpaUserRepository.save(
+                UserEntity.factory()
+                        .socialId(user.getSocialId())
+                        .socialEmail(user.getSocialEmail())
+                        .socialType(UserSocialType.valueOf(user.getSocialType()))
+                        .newInstance()
+        );
+        return saveUser.getId();
+    }
+
+    @Override
+    public void delete(final Long id) {
+
+    }
+
+    @Override
+    public void update() {
+
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -16,12 +16,12 @@ public class JpaUserAdapter implements UserPort {
 
 
     @Override
-    public Long insert(final User user) {
+    public Long insert(final User user, UserSocialType socialType) {
         final UserEntity saveUser = jpaUserRepository.save(
                 UserEntity.factory()
                         .socialId(user.getSocialId())
                         .socialEmail(user.getSocialEmail())
-                        .socialType(UserSocialType.valueOf(user.getSocialType()))
+                        .socialType(socialType)
                         .newInstance()
         );
         return saveUser.getId();

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
@@ -14,8 +14,8 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/user")
-public class UserController {
+@RequestMapping("/api/v1/auth")
+public class AuthController {
     private final SignUpUserProvider userProvider;
 
     @PostMapping("/signup") // 동작확인을 위해 id 리턴시켰습니다~

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web;
+
+
+import com.depromeet.coquality.inner.user.apllication.service.SignUpUserProvider;
+import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
+import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+    private final SignUpUserProvider userProvider;
+
+    @PostMapping("/signup") // 동작확인을 위해 id 리턴시켰습니다~
+    public Long signUp(@Valid @RequestBody final SignUpRequest request){
+        final SignUpUserUseCase signUpUserUseCase = userProvider.getSignUpService(request.getSocialType());
+        final Long userId = signUpUserUseCase.execute(request.toInnerDto());
+        return userId;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
@@ -1,0 +1,31 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust;
+
+import com.depromeet.coquality.inner.user.port.driving.dto.request.SignUpDto;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignUpRequest {
+    @NotBlank(message = "{auth.token.notBlank}")
+    private String token;
+
+    @NotNull(message = "{user.socialType.notNull}")
+    private UserSocialType socialType;
+
+    private SignUpRequest(final String token, final UserSocialType socialType) {
+        this.token = token;
+        this.socialType = socialType;
+    }
+    public static SignUpRequest of(final String token, final UserSocialType socialType){
+        return new SignUpRequest(token, socialType);
+    }
+    public SignUpDto toInnerDto(){
+        return SignUpDto.of(token, String.valueOf(socialType));
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
@@ -18,13 +18,6 @@ public class SignUpRequest {
     @NotNull(message = "{user.socialType.notNull}")
     private UserSocialType socialType;
 
-    private SignUpRequest(final String token, final UserSocialType socialType) {
-        this.token = token;
-        this.socialType = socialType;
-    }
-    public static SignUpRequest of(final String token, final UserSocialType socialType){
-        return new SignUpRequest(token, socialType);
-    }
     public SignUpDto toInnerDto(){
         return SignUpDto.of(token, String.valueOf(socialType));
     }

--- a/src/main/java/com/depromeet/coquality/outer/user/entity/SocialInfo.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/entity/SocialInfo.java
@@ -1,0 +1,37 @@
+package com.depromeet.coquality.outer.user.entity;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Embeddable
+public class SocialInfo {
+
+    @Column(length = 200, nullable = false)
+    private String socialId;
+
+    @Column(length = 200, nullable = false)
+    private String socialEmail;
+
+    @Column(length = 30, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserSocialType socialType;
+
+    private SocialInfo(final String socialId, final String socialEmail, final UserSocialType socialType) {
+        this.socialId = socialId;
+        this.socialEmail = socialEmail;
+        this.socialType = socialType;
+    }
+    public static SocialInfo of(final String socialId, final String socialEmail, final UserSocialType socialType) {
+        return new SocialInfo(socialId, socialEmail, socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
@@ -12,7 +12,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-@Entity
+@Entity(name = "User")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {

--- a/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
@@ -1,0 +1,34 @@
+package com.depromeet.coquality.outer.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50)
+    private String nickname;
+
+    @Embedded
+    private SocialInfo socialInfo;
+
+    @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
+    private UserEntity(final String socialId, final UserSocialType socialType, final String socialEmail) {
+        this.socialInfo = SocialInfo.of(socialId, socialEmail, socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/entity/UserSocialType.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/entity/UserSocialType.java
@@ -1,0 +1,23 @@
+package com.depromeet.coquality.outer.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum UserSocialType {
+    KAKAO("카카오톡"),
+    APPLE("애플"),
+    GOOGLE("구글"),
+    ;
+    private final String value;
+
+    public String getKey() {
+        return name();
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/KaKaoAuthApiClient.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/KaKaoAuthApiClient.java
@@ -1,0 +1,14 @@
+package com.depromeet.coquality.outer.user.external.client.kakao;
+
+import com.depromeet.coquality.outer.user.external.client.kakao.dto.response.KaKaoProfileResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name ="kakaoAuthApiClient", url = "https://kapi.kakao.com")
+public interface KaKaoAuthApiClient {
+
+    @GetMapping("/v2/user/me")
+    KaKaoProfileResponse getProfileInfo(@RequestHeader("Authorization") String accessToken);
+
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
@@ -10,10 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KaKaoProfileResponse {
 
-    @JsonProperty("id")
     private String id;
     @JsonProperty("kakao_account")
     private KakaoAccount account;

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
@@ -1,0 +1,21 @@
+package com.depromeet.coquality.outer.user.external.client.kakao.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KaKaoProfileResponse {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount account;
+
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KakaoAccount.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KakaoAccount.java
@@ -1,0 +1,17 @@
+package com.depromeet.coquality.outer.user.external.client.kakao.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAccount {
+    @JsonProperty("email")
+    private String email;
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KakaoAccount.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KakaoAccount.java
@@ -1,17 +1,12 @@
 package com.depromeet.coquality.outer.user.external.client.kakao.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoAccount {
-    @JsonProperty("email")
     private String email;
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/external/config/FeignClientConfig.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/config/FeignClientConfig.java
@@ -1,0 +1,9 @@
+package com.depromeet.coquality.outer.user.external.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackages = "com.depromeet.coquality")
+@Configuration
+public class FeignClientConfig {
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
@@ -1,7 +1,14 @@
 package com.depromeet.coquality.outer.user.infrastructure;
 
 import com.depromeet.coquality.outer.user.entity.UserEntity;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
+    @Query("select u from User u where u.socialInfo.socialId = :socialId and u.socialInfo.socialType = :socialType")
+    Optional<UserEntity> existsBySocialIdAndSocialType(@Param("socialId") String socialId, @Param("socialType") UserSocialType socialType);
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.coquality.outer.user.infrastructure;
+
+import com.depromeet.coquality.outer.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
+}


### PR DESCRIPTION
## 개요
close #7 
소셜 로그인 작업 중 회원가입 먼저 작업했습니다. 
JWT는 적용 전입니다!

## 작업사항
- User도메인 정보 설정
- kakao 유저 정보 조회를 위한 FeignClient 사용
- 받아온 정보를 토대로 회원가입을 위한 KaKaoSignUpService 구현
- SignUpUserProvider 구현을 통해 여러 소셜 로그인 분기처리
- 유저 정보를 토대로 UserEntity 구현
- UserEntity 저장을 위한 JpaUserRepository 구현 및 JpaUserAdapter 구현

## 변경로직
- SignUpUserUseCase 메서드 변경
- UserPort insert메서드 파라미터 알맞게 User로 변경
