### PR TITLE
implement api of creating comments and editing comments.

### DIFF
--- a/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
@@ -1,0 +1,24 @@
+package com.depromeet.coquality.inner.comment.application;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+import com.depromeet.coquality.outer.comment.adapter.driven.persistence.JpaCommentAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateCommentService implements CreateCommentUseCase {
+
+    private final JpaCommentAdapter commentAdapter;
+
+    @Override
+    public void execute(CommentDto commentDto) {
+        Comment comment = commentDto.toComment();
+
+        // TODO, add validation of user and post existence
+
+        commentAdapter.insert(comment);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
@@ -19,6 +19,6 @@ public class CreateCommentService implements CreateCommentUseCase {
 
         // TODO, add validation of user and post existence
 
-        commentAdapter.insert(comment);
+        commentAdapter.save(comment);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.inner.comment.application;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+import com.depromeet.coquality.outer.comment.adapter.driven.persistence.JpaCommentAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCommentService implements UpdateCommentUseCase {
+    private final JpaCommentAdapter commentAdapter;
+
+    @Override
+    public Comment execute(Long commentId, CommentDto commentDto) {
+        Comment comment = commentAdapter.findById(commentId);
+        Comment updatedComment = comment.update(
+                commentDto.userId(),
+                commentDto.postId(),
+                commentDto.contents()
+        );
+
+        commentAdapter.save(updatedComment);
+        return updatedComment;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
@@ -1,8 +1,10 @@
 package com.depromeet.coquality.inner.comment.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class Comment {
     private String contents;
     private Long userId;

--- a/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
@@ -1,7 +1,10 @@
 package com.depromeet.coquality.inner.comment.domain;
 
+import com.depromeet.coquality.inner.comment.exception.UpdateCommentForbiddenException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
@@ -9,4 +12,22 @@ public class Comment {
     private String contents;
     private Long userId;
     private Long postId;
+
+    // TODO, consider to have the time and commentId
+
+    public Comment update(Long userId, Long postId, String contents) {
+        applyUpdateValidation(userId, postId);
+
+        return new Comment(
+                contents,
+                userId,
+                postId
+        );
+    }
+
+    private void applyUpdateValidation(Long userId, Long postId) {
+        if (!Objects.equals(this.userId, userId) || !Objects.equals(this.postId, postId)) {
+            throw new UpdateCommentForbiddenException(0, "Edit comments forbidden.");
+        }
+    }
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,9 @@
+package com.depromeet.coquality.inner.comment.exception;
+
+import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainException;
+
+public class CommentNotFoundException extends CoQualityDomainException {
+    public CommentNotFoundException(int code, String message) {
+        super(code, message);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/exception/UpdateCommentForbiddenException.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/exception/UpdateCommentForbiddenException.java
@@ -1,0 +1,9 @@
+package com.depromeet.coquality.inner.comment.exception;
+
+import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainException;
+
+public class UpdateCommentForbiddenException extends CoQualityDomainException {
+    public UpdateCommentForbiddenException(int code, String message) {
+        super(code, message);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
@@ -3,5 +3,7 @@ package com.depromeet.coquality.inner.comment.port.driven;
 import com.depromeet.coquality.inner.comment.domain.Comment;
 
 public interface CommentPort {
-    void insert(final Comment comment);
+    void save(final Comment comment);
+
+    Comment findById(Long commentId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/CreateCommentUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/CreateCommentUseCase.java
@@ -1,5 +1,7 @@
 package com.depromeet.coquality.inner.comment.port.driving;
 
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+
 public interface CreateCommentUseCase {
-    void execute();
+    void execute(CommentDto commentDto);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/UpdateCommentUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/UpdateCommentUseCase.java
@@ -1,5 +1,8 @@
 package com.depromeet.coquality.inner.comment.port.driving;
 
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+
 public interface UpdateCommentUseCase {
-    void execute();
+    Comment execute(Long commentId, CommentDto commentDto);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/dto/CommentDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/dto/CommentDto.java
@@ -1,0 +1,17 @@
+package com.depromeet.coquality.inner.comment.port.driving.dto;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+
+public record CommentDto(
+        String contents,
+        Long userId,
+        Long postId
+) {
+    public Comment toComment() {
+        return new Comment(
+                contents,
+                userId,
+                postId
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -1,11 +1,17 @@
 package com.depromeet.coquality.outer.comment.adapter.driven.persistence;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.exception.CommentNotFoundException;
 import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
 import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+
+import static java.text.MessageFormat.*;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +19,7 @@ public class JpaCommentAdapter implements CommentPort {
     private final JpaCommentRepository jpaCommentRepository;
 
     @Override
-    public void insert(Comment comment) {
+    public void save(Comment comment) {
         jpaCommentRepository.save(
                 CommentEntity.factory()
                         .contents(comment.getContents())
@@ -21,5 +27,22 @@ public class JpaCommentAdapter implements CommentPort {
                         .postId(comment.getPostId())
                         .newInstance()
         );
+    }
+
+    @Override
+    public Comment findById(Long commentId) {
+        Optional<CommentEntity> optionalCommentEntity = jpaCommentRepository.findById(commentId);
+
+        if (optionalCommentEntity.isPresent()) {
+            CommentEntity commentEntity = optionalCommentEntity.get();
+            return new Comment(
+                    commentEntity.getContents(),
+                    commentEntity.getUserId(),
+                    commentEntity.getPostId()
+            );
+        }
+
+        // TODO, change code or remove unnecessary code
+        throw new CommentNotFoundException(0, format("Comment not found. id: {0}", commentId));
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -1,0 +1,29 @@
+package com.depromeet.coquality.outer.comment.adapter.driving.web;
+
+import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
+import com.depromeet.coquality.outer.comment.adapter.driving.web.request.CreateCommentRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+public class CommentController {
+
+    private final CreateCommentUseCase createCommentUseCase;
+
+    @PostMapping
+    public void createComment(
+            @Valid @RequestBody final CreateCommentRequest createCommentRequest
+            // @UserPrincipal User user
+    ) {
+        // TODO, use the resolver to get the user where auth is required
+        Long userId = 1L; // TODO, sample
+        createCommentUseCase.execute(createCommentRequest.toCommentDto(userId));
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -1,11 +1,17 @@
 package com.depromeet.coquality.outer.comment.adapter.driving.web;
 
+import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
+import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.CreateCommentRequest;
+import com.depromeet.coquality.outer.comment.adapter.driving.web.request.UpdateCommentRequest;
+import com.depromeet.coquality.outer.comment.adapter.driving.web.response.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -16,6 +22,7 @@ import javax.validation.Valid;
 public class CommentController {
 
     private final CreateCommentUseCase createCommentUseCase;
+    private final UpdateCommentUseCase updateCommentUseCase;
 
     @PostMapping
     public void createComment(
@@ -25,5 +32,17 @@ public class CommentController {
         // TODO, use the resolver to get the user where auth is required
         Long userId = 1L; // TODO, sample
         createCommentUseCase.execute(createCommentRequest.toCommentDto(userId));
+    }
+
+    @PutMapping("/{commentId}")
+    public CommentResponse updateComment(
+            @RequestParam Long commentId,
+            @Valid @RequestBody final UpdateCommentRequest updateCommentRequest
+            // @UserPrincipal User user
+    ) {
+        // TODO, use the resolver to get the user where auth is required
+        Long userId = 1L; // TODO, sample
+        Comment updatedComment = updateCommentUseCase.execute(commentId, updateCommentRequest.toCommentDto(userId));
+        return CommentResponse.from(updatedComment);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/CreateCommentRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/CreateCommentRequest.java
@@ -1,0 +1,19 @@
+package com.depromeet.coquality.outer.comment.adapter.driving.web.request;
+
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record CreateCommentRequest(
+        @NotNull Long postId,
+        @NotBlank String contents
+) {
+    public CommentDto toCommentDto(Long userId) {
+        return new CommentDto(
+                contents,
+                userId,
+                postId
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/UpdateCommentRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/UpdateCommentRequest.java
@@ -1,0 +1,19 @@
+package com.depromeet.coquality.outer.comment.adapter.driving.web.request;
+
+import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record UpdateCommentRequest(
+        @NotNull Long postId,
+        @NotBlank String contents
+) {
+    public CommentDto toCommentDto(Long userId) {
+        return new CommentDto(
+                contents,
+                userId,
+                postId
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentResponse.java
@@ -1,0 +1,26 @@
+package com.depromeet.coquality.outer.comment.adapter.driving.web.response;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long postId,
+        Long userId,
+        Long commentId,
+        String contents,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static CommentResponse from(Comment comment) {
+        // TODO, refactor commentId and time
+        return new CommentResponse(
+                comment.getPostId(),
+                comment.getUserId(),
+                1L,
+                comment.getContents(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/common/exception/ErrorResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.coquality.outer.common.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private int code;
+    private String message;
+
+    public static ErrorResponse of(int code, String message) {
+        return new ErrorResponse(code, message);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.depromeet.coquality.outer.common.exception;
+
+import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CoQualityDomainException.class)
+    public ResponseEntity<ErrorResponse> handleCoQualityDomainException(CoQualityDomainException e) {
+        // TODO, add log when ready
+        // log.info(String.format("%s %s", e.getClass().getName(), e);
+
+        // TODO, inject status
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(e.getCode(), e.getMessage()));
+    }
+
+}


### PR DESCRIPTION
## 개요
close #5 
댓글 작성 API 연결 및 댓글 수정 API를 구현했어요.

## 작업사항
- Comment가 수정/생성 시각 및 ID를 갖는게 좋을지 아직 고민 중..
- Exception 관련해서는 우선 임의로 작업했어요.
- 댓글 생성, 수정 등에 대해서 User를 리졸빙해오는 리졸버 등 다른 도메인과 관련된 건 일단 주석으로 처리하고 임의 상수로 박았어요.

## 변경로직
- 내용을 적어주세요.

고민할 시간이 적다보니 러프하게 구현하게 되는데, 일단 뼈대만 먼저 세운 담에 리팩터링 해나갈 예정이에요!
