### PR TITLE
feat: oauth 로그인 추가 및 JWT 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 
     //open feign
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignInUserProvider.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/SignInUserProvider.java
@@ -1,0 +1,32 @@
+package com.depromeet.coquality.inner.user.apllication.service;
+
+
+import com.depromeet.coquality.inner.user.apllication.service.kakao.KakaoSignInService;
+import com.depromeet.coquality.inner.user.port.driving.SignInUserUseCase;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SignInUserProvider {
+    private final Map<UserSocialType, SignInUserUseCase> signInUserUseCaseMap = new HashMap<>();
+
+    private final KakaoSignInService kaKaoSignUpService;
+    //TODO 애플, 구글 확장 고려
+//    private final AppleAuthService appleSignUpService;
+//    private final GoogleAuthService googleSignUpService;
+
+    @PostConstruct
+    void initializeAuthServicesMap() {
+        signInUserUseCaseMap.put(UserSocialType.KAKAO, kaKaoSignUpService);
+//        authServiceMap.put(UserSocialType.APPLE, appleSignUpService);
+//        authServiceMap.put(UserSocialType.GOOGLE, googleSignUpService);
+    }
+    public SignInUserUseCase getSignUpService(final UserSocialType socialType) {
+        return signInUserUseCaseMap.get(socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KakaoSignInService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KakaoSignInService.java
@@ -23,6 +23,6 @@ public class KakaoSignInService implements SignInUserUseCase {
     @Override
     public Long execute(final LoginDto request) {
         final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
-        return userPort.selectUserWhereSocialIdAndSocialType(response.getId(), socialType);
+        return userPort.findUserBySocialIdAndSocialType(response.getId(), socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KakaoSignInService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KakaoSignInService.java
@@ -1,0 +1,28 @@
+package com.depromeet.coquality.inner.user.apllication.service.kakao;
+
+
+import com.depromeet.coquality.inner.common.util.HttpHeaderUtils;
+import com.depromeet.coquality.inner.user.port.driven.UserPort;
+import com.depromeet.coquality.inner.user.port.driving.SignInUserUseCase;
+import com.depromeet.coquality.inner.user.port.driving.dto.request.LoginDto;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import com.depromeet.coquality.outer.user.external.client.kakao.KaKaoAuthApiClient;
+import com.depromeet.coquality.outer.user.external.client.kakao.dto.response.KaKaoProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class KakaoSignInService implements SignInUserUseCase {
+    private static final UserSocialType socialType = UserSocialType.KAKAO;
+    private final UserPort userPort;
+    private final KaKaoAuthApiClient kakaoAuthApiCaller;
+
+    @Override
+    public Long execute(final LoginDto request) {
+        final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
+        return userPort.selectUserWhereSocialIdAndSocialType(response.getId(), socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/utils/SignUpUserServiceUtils.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/utils/SignUpUserServiceUtils.java
@@ -14,7 +14,7 @@ public class SignUpUserServiceUtils {
     private final JpaUserRepository jpaUserRepository;
 
     public void validateNotExistsUser(final String socialId, final UserSocialType socialType) {
-        final Optional<UserEntity> existUser = jpaUserRepository.existsBySocialIdAndSocialType(socialId, socialType);
+        final Optional<UserEntity> existUser = jpaUserRepository.findBySocialIdAndSocialType(socialId, socialType);
         if (existUser.isPresent()){
             throw new IllegalArgumentException(String.format("이미 존재하는 유저 (%s - %s) 입니다", socialId, socialType));
         }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
@@ -7,6 +7,8 @@ import com.depromeet.coquality.outer.user.entity.UserSocialType;
 public interface UserPort {
     Long insert(User user, UserSocialType socialType);
 
+    Long selectUserWhereSocialIdAndSocialType(String socialId, UserSocialType userSocialType);
+
     void delete(final Long id);
 
     void update();

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
@@ -7,7 +7,7 @@ import com.depromeet.coquality.outer.user.entity.UserSocialType;
 public interface UserPort {
     Long insert(User user, UserSocialType socialType);
 
-    Long selectUserWhereSocialIdAndSocialType(String socialId, UserSocialType userSocialType);
+    Long findUserBySocialIdAndSocialType(String socialId, UserSocialType userSocialType);
 
     void delete(final Long id);
 

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/SignInUserUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/SignInUserUseCase.java
@@ -1,5 +1,7 @@
 package com.depromeet.coquality.inner.user.port.driving;
 
+import com.depromeet.coquality.inner.user.port.driving.dto.request.LoginDto;
+
 public interface SignInUserUseCase {
-    void execute();
+    Long execute(LoginDto loginDto);
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/LoginDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/LoginDto.java
@@ -1,0 +1,18 @@
+package com.depromeet.coquality.inner.user.port.driving.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LoginDto {
+    private String token;
+
+    private String socialType;
+
+    private LoginDto(final String token, final String socialType) {
+        this.token = token;
+        this.socialType = socialType;
+    }
+    public static LoginDto of(String token, String socialType) {
+        return new LoginDto(token, socialType);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/common/config/AuthorizationSwaggerConfig.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/config/AuthorizationSwaggerConfig.java
@@ -1,0 +1,51 @@
+package com.depromeet.coquality.outer.common.config;
+
+
+import com.depromeet.coquality.outer.interceptor.Auth;
+import java.util.List;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.documentation.builders.RequestParameterBuilder;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.ParameterType;
+import springfox.documentation.service.RequestParameter;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.OperationBuilderPlugin;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.swagger.common.SwaggerPluginSupport;
+
+@Component
+@Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER + 1000)
+public class AuthorizationSwaggerConfig implements OperationBuilderPlugin {
+    @Override
+    public void apply(final OperationContext context) {
+        if (context.findAnnotation(Auth.class).isPresent()) {
+            context.operationBuilder()
+                    .requestParameters(List.of(authorizationHeader()))
+                    .authorizations(List.of(SecurityReference.builder()
+                            .reference("Authorization")
+                            .scopes(authorizationScopes())
+                            .build()))
+                    .build();
+        }
+    }
+    private AuthorizationScope[] authorizationScopes() {
+        final AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = new AuthorizationScope("", "");
+        return authorizationScopes;
+    }
+
+    private RequestParameter authorizationHeader() {
+        return new RequestParameterBuilder()
+                .name("Authorization")
+                .required(false)
+                .in(ParameterType.HEADER)
+                .build();
+    }
+
+    @Override
+    public boolean supports(final DocumentationType delimiter) {
+        return true;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/common/config/WebConfig.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.depromeet.coquality.outer.common.config;
+
+import com.depromeet.coquality.outer.interceptor.AuthInterceptor;
+import com.depromeet.coquality.outer.resolver.UserIdResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final UserIdResolver userIdResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdResolver);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/interceptor/Auth.java
+++ b/src/main/java/com/depromeet/coquality/outer/interceptor/Auth.java
@@ -1,0 +1,12 @@
+package com.depromeet.coquality.outer.interceptor;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/depromeet/coquality/outer/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/depromeet/coquality/outer/interceptor/AuthInterceptor.java
@@ -1,0 +1,29 @@
+package com.depromeet.coquality.outer.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    private final LoginCheckHandler loginCheckHandler;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        Auth auth = handlerMethod.getMethodAnnotation(Auth.class);
+        if (auth == null) {
+            return true;
+        }
+        Long userId = loginCheckHandler.getUserId(request);
+        return true;
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/interceptor/LoginCheckHandler.java
+++ b/src/main/java/com/depromeet/coquality/outer/interceptor/LoginCheckHandler.java
@@ -1,0 +1,27 @@
+package com.depromeet.coquality.outer.interceptor;
+
+import static com.depromeet.coquality.outer.jwt.JwtHeader.AUTH;
+
+import com.depromeet.coquality.outer.jwt.JwtService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LoginCheckHandler {
+    private final JwtService jwtService;
+    Long getUserId(final HttpServletRequest request) {
+        final String token = request.getHeader(AUTH);
+        if (!jwtService.verifyToken(token)) {
+            throw new IllegalArgumentException();
+        }
+
+        final String subject = jwtService.getSubject(token);
+        return convertToUserId(subject);
+    }
+
+    private long convertToUserId(final String subject) {
+        return Long.parseLong(subject);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/jwt/JwtHeader.java
+++ b/src/main/java/com/depromeet/coquality/outer/jwt/JwtHeader.java
@@ -1,0 +1,5 @@
+package com.depromeet.coquality.outer.jwt;
+
+public class JwtHeader {
+    public static final String AUTH = "AUTH";
+}

--- a/src/main/java/com/depromeet/coquality/outer/jwt/JwtService.java
+++ b/src/main/java/com/depromeet/coquality/outer/jwt/JwtService.java
@@ -1,0 +1,9 @@
+package com.depromeet.coquality.outer.jwt;
+
+public interface JwtService {
+    String issuedToken(String subject, String role, long periodSecond);
+
+    boolean verifyToken(String token);
+
+    String getSubject(String token);
+}

--- a/src/main/java/com/depromeet/coquality/outer/jwt/SimpleJwtService.java
+++ b/src/main/java/com/depromeet/coquality/outer/jwt/SimpleJwtService.java
@@ -1,0 +1,57 @@
+package com.depromeet.coquality.outer.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SimpleJwtService implements JwtService{
+    private static final String SECRET = "가나다라마바사아자차카타파하에헤으에으에으에으에으에으에으에으에으어허허허";
+    @Override
+    public String issuedToken(final String subject, final String role, final long periodSecond) {
+        final Claims claims = Jwts.claims().setSubject(subject);
+        claims.put("role", role);
+
+        final Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + periodSecond * 1000))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    @Override
+    public boolean verifyToken(final String token) {
+        try {
+            final Claims claims = getBody(token);
+            return claims.getExpiration().after(new Date());
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getSubject(final String token) {
+        final Claims claims = getBody(token);
+
+        return claims.getSubject();
+    }
+
+    private Key getSigningKey() {
+        final byte[] keyBytes = SECRET.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/resolver/UserId.java
+++ b/src/main/java/com/depromeet/coquality/outer/resolver/UserId.java
@@ -1,0 +1,11 @@
+package com.depromeet.coquality.outer.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/com/depromeet/coquality/outer/resolver/UserIdResolver.java
+++ b/src/main/java/com/depromeet/coquality/outer/resolver/UserIdResolver.java
@@ -1,0 +1,45 @@
+package com.depromeet.coquality.outer.resolver;
+
+import static com.depromeet.coquality.outer.jwt.JwtHeader.AUTH;
+
+import com.depromeet.coquality.outer.interceptor.Auth;
+import com.depromeet.coquality.outer.jwt.JwtService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class UserIdResolver implements HandlerMethodArgumentResolver {
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class) && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        if (parameter.getMethodAnnotation(Auth.class) == null) {
+            throw new RuntimeException("인증이 필요한 컨트롤러 입니다. @Auth 어노테이션을 붙여주세요.");
+        }
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = request.getHeader(AUTH);
+        if (!jwtService.verifyToken(token)) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+
+        final String subject = jwtService.getSubject(token);
+        try {
+            return Long.parseLong(subject);
+        } catch (final NumberFormatException e) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -16,7 +16,7 @@ public class JpaUserAdapter implements UserPort {
 
 
     @Override
-    public Long insert(final User user, UserSocialType socialType) {
+    public Long insert(final User user, final UserSocialType socialType) {
         final UserEntity saveUser = jpaUserRepository.save(
                 UserEntity.factory()
                         .socialId(user.getSocialId())

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -5,6 +5,7 @@ import com.depromeet.coquality.inner.user.port.driven.UserPort;
 import com.depromeet.coquality.outer.user.entity.UserEntity;
 import com.depromeet.coquality.outer.user.entity.UserSocialType;
 import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,16 @@ public class JpaUserAdapter implements UserPort {
                         .newInstance()
         );
         return saveUser.getId();
+    }
+
+    @Override
+    public Long selectUserWhereSocialIdAndSocialType(final String socialId, final UserSocialType socialType) {
+        final UserEntity findUser = jpaUserRepository.findBySocialIdAndSocialType(socialId, socialType)
+                .orElseThrow(() -> new IllegalArgumentException());
+        if (Objects.isNull(findUser)){
+            throw new IllegalArgumentException(String.format("존재하지 않는 유저 (%s - %s) 입니다", socialId, socialType));
+        }
+        return findUser.getId();
     }
 
     @Override

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -29,12 +29,9 @@ public class JpaUserAdapter implements UserPort {
     }
 
     @Override
-    public Long selectUserWhereSocialIdAndSocialType(final String socialId, final UserSocialType socialType) {
+    public Long findUserBySocialIdAndSocialType(final String socialId, final UserSocialType socialType) {
         final UserEntity findUser = jpaUserRepository.findBySocialIdAndSocialType(socialId, socialType)
-                .orElseThrow(() -> new IllegalArgumentException());
-        if (Objects.isNull(findUser)){
-            throw new IllegalArgumentException(String.format("존재하지 않는 유저 (%s - %s) 입니다", socialId, socialType));
-        }
+                .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 유저 (%s - %s) 입니다", socialId, socialType)));
         return findUser.getId();
     }
 

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -5,7 +5,6 @@ import com.depromeet.coquality.inner.user.port.driven.UserPort;
 import com.depromeet.coquality.outer.user.entity.UserEntity;
 import com.depromeet.coquality.outer.user.entity.UserSocialType;
 import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
@@ -5,8 +5,12 @@ import com.depromeet.coquality.inner.user.apllication.service.SignInUserProvider
 import com.depromeet.coquality.inner.user.apllication.service.SignUpUserProvider;
 import com.depromeet.coquality.inner.user.port.driving.SignInUserUseCase;
 import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
+import com.depromeet.coquality.outer.jwt.JwtService;
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.LoginRequest;
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.SignUpRequest;
+import com.depromeet.coquality.outer.user.adapter.driving.web.dto.response.LoginResponse;
+import com.depromeet.coquality.outer.user.adapter.driving.web.dto.response.SignUpResponse;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,17 +25,20 @@ import javax.validation.Valid;
 public class AuthController {
     private final SignUpUserProvider signUpUserProvider;
     private final SignInUserProvider signInUserProvider;
+    private final JwtService jwtService;
 
     @PostMapping("/signup")
-    public Long signUp(@Valid @RequestBody final SignUpRequest request){
+    public SignUpResponse signUp(@Valid @RequestBody final SignUpRequest request){
         final SignUpUserUseCase signUpUserUseCase = signUpUserProvider.getSignUpService(request.getSocialType());
         final Long userId = signUpUserUseCase.execute(request.toInnerDto());
-        return userId;
+        final String token = jwtService.issuedToken(String.valueOf(userId), "USER", 60 * 60 * 24 * 30L);
+        return SignUpResponse.of(token, userId);
     }
     @PostMapping("/singin")
-    public Long signIn(@Valid @RequestBody final LoginRequest request){
+    public LoginResponse signIn(@Valid @RequestBody final LoginRequest request){
         final SignInUserUseCase signInUserUseCase = signInUserProvider.getSignUpService(request.getSocialType());
         final Long userId = signInUserUseCase.execute(request.toInnerDto());
-        return userId;
+        final String token = jwtService.issuedToken(String.valueOf(userId), "USER", 60 * 60 * 24 * 30L);
+        return LoginResponse.of(token, userId);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
@@ -10,7 +10,6 @@ import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.LoginR
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.SignUpRequest;
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.response.LoginResponse;
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.response.SignUpResponse;
-import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
@@ -1,8 +1,11 @@
 package com.depromeet.coquality.outer.user.adapter.driving.web;
 
 
+import com.depromeet.coquality.inner.user.apllication.service.SignInUserProvider;
 import com.depromeet.coquality.inner.user.apllication.service.SignUpUserProvider;
+import com.depromeet.coquality.inner.user.port.driving.SignInUserUseCase;
 import com.depromeet.coquality.inner.user.port.driving.SignUpUserUseCase;
+import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.LoginRequest;
 import com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,12 +19,19 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
-    private final SignUpUserProvider userProvider;
+    private final SignUpUserProvider signUpUserProvider;
+    private final SignInUserProvider signInUserProvider;
 
-    @PostMapping("/signup") // 동작확인을 위해 id 리턴시켰습니다~
+    @PostMapping("/signup")
     public Long signUp(@Valid @RequestBody final SignUpRequest request){
-        final SignUpUserUseCase signUpUserUseCase = userProvider.getSignUpService(request.getSocialType());
+        final SignUpUserUseCase signUpUserUseCase = signUpUserProvider.getSignUpService(request.getSocialType());
         final Long userId = signUpUserUseCase.execute(request.toInnerDto());
+        return userId;
+    }
+    @PostMapping("/singin")
+    public Long signIn(@Valid @RequestBody final LoginRequest request){
+        final SignInUserUseCase signInUserUseCase = signInUserProvider.getSignUpService(request.getSocialType());
+        final Long userId = signInUserUseCase.execute(request.toInnerDto());
         return userId;
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/LoginRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web.dto.reqeust;
+
+
+import com.depromeet.coquality.inner.user.port.driving.dto.request.LoginDto;
+import com.depromeet.coquality.outer.user.entity.UserSocialType;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    @NotBlank(message = "{auth.token.notBlank}")
+    private String token;
+
+    @NotNull(message = "{user.socialType.notNull}")
+    private UserSocialType socialType;
+
+    public LoginDto toInnerDto(){
+        return LoginDto.of(token, String.valueOf(socialType));
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/LoginResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+    private String token;
+    private Long userId;
+
+    private LoginResponse(final String token, final Long userId) {
+        this.token = token;
+        this.userId = userId;
+    }
+
+    public static LoginResponse of(final String token, final Long userId){
+        return new LoginResponse(token,userId);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/SignUpResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/SignUpResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class SignUpResponse {
+    private String token;
+    private Long userId;
+
+    private SignUpResponse(final String token, final Long userId) {
+        this.token = token;
+        this.userId = userId;
+    }
+
+    public static SignUpResponse of(final String token, final Long userId){
+        return new SignUpResponse(token,userId);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/infrastructure/JpaUserRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
     @Query("select u from User u where u.socialInfo.socialId = :socialId and u.socialInfo.socialType = :socialType")
-    Optional<UserEntity> existsBySocialIdAndSocialType(@Param("socialId") String socialId, @Param("socialType") UserSocialType socialType);
+    Optional<UserEntity> findBySocialIdAndSocialType(@Param("socialId") String socialId, @Param("socialType") UserSocialType socialType);
 }


### PR DESCRIPTION
## 개요
close #10 #7 
소셜 로그인/회원가입 모두 구현했고, JWT 도입했습니다!
추가로 Response 형태나 exception 등이 아직 상의되지 않아서 이거 다 결정되면 반영하겠습니다.

## 작업사항
- userId 바인딩을 위한 리졸버 구현
- JWT를 위한 JWT 클래스 구현
- Auth 애노테이션 사용을 위한 interceptor 구현
- oauth 로그인 로직 구현

## 변경로직
- response 형태 일단 json 형태로 만들어뒀습니다.
- 일부 메서드(socialId와 socialType으로 유저 조회하는 메서드) 이름 변경했습니다.
