### PR TITLE
[FEAT] 내 정보 조회하기 기능 구현

### DIFF
--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/ReadUserService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/ReadUserService.java
@@ -1,0 +1,21 @@
+package com.depromeet.coquality.inner.user.apllication.service;
+
+import com.depromeet.coquality.inner.user.domain.User;
+import com.depromeet.coquality.inner.user.port.driven.UserPort;
+import com.depromeet.coquality.inner.user.port.driving.ReadUserUserCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ReadUserService implements ReadUserUserCase {
+    private final UserPort userPort;
+
+
+    @Override
+    public User execute(Long userId) {
+        return userPort.fetch(userId);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
@@ -9,12 +9,18 @@ public class User {
     private String socialId;
     private String socialEmail;
 
-    private User(final String socialId, final String socialEmail) {
+    private User(final String nickname, final String socialId, final String socialEmail) {
+        this.nickname = nickname;
         this.socialId = socialId;
         this.socialEmail = socialEmail;
         UserValidationPolicy.validate(this);
     }
-    public static User of(final String socialId, final String socialEmail){
-        return new User(socialId, socialEmail);
+
+    public static User of(final String socialId, final String socialEmail) {
+        return new User(null, socialId, socialEmail);
+    }
+
+    public static User of(final String nickname, final String socialId, final String socialEmail){
+        return new User(nickname, socialId, socialEmail);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driven/UserPort.java
@@ -12,4 +12,6 @@ public interface UserPort {
     void delete(final Long id);
 
     void update();
+
+    User fetch(Long userId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/ReadUserUserCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/ReadUserUserCase.java
@@ -1,0 +1,7 @@
+package com.depromeet.coquality.inner.user.port.driving;
+
+import com.depromeet.coquality.inner.user.domain.User;
+
+public interface ReadUserUserCase {
+    User execute(final Long userId);
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -30,7 +30,8 @@ public class JpaUserAdapter implements UserPort {
     @Override
     public Long findUserBySocialIdAndSocialType(final String socialId, final UserSocialType socialType) {
         final UserEntity findUser = jpaUserRepository.findBySocialIdAndSocialType(socialId, socialType)
-                .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 유저 (%s - %s) 입니다", socialId, socialType)));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("존재하지 않는 유저 (%s - %s) 입니다", socialId, socialType)));
         return findUser.getId();
     }
 
@@ -42,5 +43,17 @@ public class JpaUserAdapter implements UserPort {
     @Override
     public void update() {
 
+    }
+
+    @Override
+    public User fetch(final Long userId) {
+        final UserEntity findUser = jpaUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        return User.of(
+                findUser.getNickname(),
+                findUser.getSocialInfo().getSocialId(),
+                findUser.getSocialInfo().getSocialEmail()
+        );
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
@@ -1,0 +1,26 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web;
+
+import com.depromeet.coquality.inner.user.domain.User;
+import com.depromeet.coquality.inner.user.port.driving.ReadUserUserCase;
+import com.depromeet.coquality.outer.interceptor.Auth;
+import com.depromeet.coquality.outer.resolver.UserId;
+import com.depromeet.coquality.outer.user.adapter.driving.web.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final ReadUserUserCase readUserUserCase;
+
+    @Auth
+    @GetMapping("/read")
+    public UserResponse readUser(@UserId final Long userId) {
+        final User user = readUserUserCase.execute(userId);
+        return UserResponse.of(userId, user.getNickname());
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
 
     @Auth
     @GetMapping("/read")
-    public UserResponse readUser(@UserId final Long userId) {
+    public UserResponse readMyInfo(@UserId final Long userId) {
         final User user = readUserUserCase.execute(userId);
         return UserResponse.of(userId, user.getNickname());
     }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/UserResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/UserResponse.java
@@ -1,0 +1,20 @@
+package com.depromeet.coquality.outer.user.adapter.driving.web.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+    private final Long userId;
+    private final String nickname;
+
+    private UserResponse(final Long userId, final String nickname) {
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+
+    public static UserResponse of(final Long userId, final String nickname){
+        return new UserResponse(userId, nickname);
+    }
+
+}


### PR DESCRIPTION
## 개요
유저 정보 조회하기 기능 구현했습니다. 아직 닉네임을 회원가입 시에 받을지 수정에서 받을지, 한줄소개 또한 회원가입시에 받을지 수정에서 받을지 정확하게 파악이 안되서 이부분 결정되면 바로 반영하겠습니다.

추가로 @Auth 어노테이션과 @UserId 어노테이션을 통해 헤더에 jwt 넣어주시면 됩니당.

## 작업사항
- 유저 정보 조회하기 기능 구현


![image](https://user-images.githubusercontent.com/81547780/200775984-509d902d-b849-4e91-a0c2-7e092fc846c4.png)
