### PR TITLE
[FIX] 유저 닉네임과 이메일도 직접 받는 것으로 결정되어 추가했습니다.

### DIFF
--- a/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/apllication/service/kakao/KaKaoSignUpService.java
@@ -27,6 +27,6 @@ public class KaKaoSignUpService implements SignUpUserUseCase {
     public Long execute(final SignUpDto request) {
         final KaKaoProfileResponse response = kakaoAuthApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
         signUpUserServiceUtils.validateNotExistsUser(response.getId(), socialType);
-        return userPort.insert(User.of(response.getId(), response.getAccount().getEmail()), socialType);
+        return userPort.insert(User.of(request.getNickname(), response.getId(), request.getEmail()), socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/domain/User.java
@@ -16,10 +16,6 @@ public class User {
         UserValidationPolicy.validate(this);
     }
 
-    public static User of(final String socialId, final String socialEmail) {
-        return new User(null, socialId, socialEmail);
-    }
-
     public static User of(final String nickname, final String socialId, final String socialEmail){
         return new User(nickname, socialId, socialEmail);
     }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
@@ -8,12 +8,18 @@ public class SignUpDto {
     private String token;
     private String socialType;
 
-    private SignUpDto(final String token, final String socialType) {
+    private String nickname;
+
+    private String email;
+
+    private SignUpDto(final String token, final String socialType, final String nickname, final String email) {
         this.token = token;
         this.socialType = socialType;
+        this.nickname = nickname;
+        this.email = email;
     }
 
-    public static SignUpDto of(final String token, final String socialType) {
-        return new SignUpDto(token, socialType);
+    public static SignUpDto of(final String token, final String socialType, final String nickname, final String email) {
+        return new SignUpDto(token, socialType, nickname, email);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
+++ b/src/main/java/com/depromeet/coquality/inner/user/port/driving/dto/request/SignUpDto.java
@@ -10,7 +10,7 @@ public class SignUpDto {
 
     private String nickname;
 
-    private String email;
+    private final String email;
 
     private SignUpDto(final String token, final String socialType, final String nickname, final String email) {
         this.token = token;

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driven/persistance/JpaUserAdapter.java
@@ -19,6 +19,7 @@ public class JpaUserAdapter implements UserPort {
     public Long insert(final User user, final UserSocialType socialType) {
         final UserEntity saveUser = jpaUserRepository.save(
                 UserEntity.factory()
+                        .nickname(user.getNickname())
                         .socialId(user.getSocialId())
                         .socialEmail(user.getSocialEmail())
                         .socialType(socialType)

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/reqeust/SignUpRequest.java
@@ -18,7 +18,13 @@ public class SignUpRequest {
     @NotNull(message = "{user.socialType.notNull}")
     private UserSocialType socialType;
 
+    @NotNull
+    private String nickname;
+
+    @NotNull
+    private String email;
+
     public SignUpDto toInnerDto(){
-        return SignUpDto.of(token, String.valueOf(socialType));
+        return SignUpDto.of(token, String.valueOf(socialType), nickname, email);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/entity/UserEntity.java
@@ -28,7 +28,8 @@ public class UserEntity {
     private SocialInfo socialInfo;
 
     @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
-    private UserEntity(final String socialId, final UserSocialType socialType, final String socialEmail) {
+    private UserEntity(final String nickname, final String socialId, final UserSocialType socialType, final String socialEmail) {
+        this.nickname = nickname;
         this.socialInfo = SocialInfo.of(socialId, socialEmail, socialType);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/external/client/kakao/dto/response/KaKaoProfileResponse.java
@@ -1,9 +1,6 @@
 package com.depromeet.coquality.outer.user.external.client.kakao.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,7 +10,5 @@ import lombok.NoArgsConstructor;
 public class KaKaoProfileResponse {
 
     private String id;
-    @JsonProperty("kakao_account")
-    private KakaoAccount account;
 
 }


### PR DESCRIPTION
## 개요
유저 닉네임과 이메일도 직접 받는 것으로 결정되어 추가했습니다.

## 작업사항
- 유저 닉네임 받는 request 추가
- 유저 이메일 받는 request 추가
- 그에 따른 로직 변경

## 변경로직
-  카카오 로그인 시 카카오에서 들고오는 response 변경
- 유저 생성 로직 변경
