### PR TITLE
댓글 조회하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ plugins {
     id 'java'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
+jar {
+    enabled = false
+}
 
 group = 'com.depromeet.coQuality'
 version = '0.0.1-SNAPSHOT'

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
@@ -6,6 +6,7 @@ import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
 import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class CreateCommentService implements CreateCommentUseCase {
     private final CommentPort commentPort;
 
     @Override
+    @Transactional
     public void execute(final CommentDto commentDto) {
         final Comment comment = commentDto.toComment();
         commentPort.save(comment);

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/CreateCommentService.java
@@ -14,8 +14,8 @@ public class CreateCommentService implements CreateCommentUseCase {
     private final CommentPort commentPort;
 
     @Override
-    public void execute(CommentDto commentDto) {
-        Comment comment = commentDto.toComment();
+    public void execute(final CommentDto commentDto) {
+        final Comment comment = commentDto.toComment();
         commentPort.save(comment);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/DeleteCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/DeleteCommentService.java
@@ -4,6 +4,7 @@ import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
 import com.depromeet.coquality.inner.comment.port.driving.DeleteCommentUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +13,7 @@ public class DeleteCommentService implements DeleteCommentUseCase {
     private final CommentPort commentPort;
 
     @Override
+    @Transactional
     public void execute(final Long commentId, final Long postId, final Long userId) {
         commentPort.delete(commentId, postId, userId);
     }

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/DeleteCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/DeleteCommentService.java
@@ -1,0 +1,18 @@
+package com.depromeet.coquality.inner.comment.application;
+
+import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
+import com.depromeet.coquality.inner.comment.port.driving.DeleteCommentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteCommentService implements DeleteCommentUseCase {
+
+    private final CommentPort commentPort;
+
+    @Override
+    public void execute(final Long commentId, final Long postId, final Long userId) {
+        commentPort.delete(commentId, postId, userId);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/ReadCommentsService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/ReadCommentsService.java
@@ -1,8 +1,8 @@
 package com.depromeet.coquality.inner.comment.application;
 
-import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
 import com.depromeet.coquality.inner.comment.port.driving.ReadCommentsUserCase;
+import com.depromeet.coquality.inner.comment.vo.CommentResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class ReadCommentsService implements ReadCommentsUserCase {
 
     @Transactional
     @Override
-    public List<Comment> execute(final Long postId) {
+    public List<CommentResponse> execute(final Long postId) {
         return commentPort.fetch(postId);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/ReadCommentsService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/ReadCommentsService.java
@@ -1,0 +1,22 @@
+package com.depromeet.coquality.inner.comment.application;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
+import com.depromeet.coquality.inner.comment.port.driving.ReadCommentsUserCase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ReadCommentsService implements ReadCommentsUserCase {
+
+    private final CommentPort commentPort;
+
+    @Transactional
+    @Override
+    public List<Comment> execute(final Long postId) {
+        return commentPort.fetch(postId);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
@@ -13,10 +13,10 @@ public class UpdateCommentService implements UpdateCommentUseCase {
     private final CommentPort commentPort;
 
     @Override
-    public Comment execute(Long commentId, CommentDto commentDto) {
-        Comment comment = commentPort.findById(commentId);
+    public Comment execute(final Long commentId, final CommentDto commentDto) {
+        final Comment comment = commentPort.findById(commentId);
 
-        Comment updatedComment = comment.update(
+        final Comment updatedComment = comment.update(
                 commentDto.userId(),
                 commentDto.postId(),
                 commentDto.contents()

--- a/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/application/UpdateCommentService.java
@@ -6,6 +6,7 @@ import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
 import com.depromeet.coquality.inner.comment.port.driving.dto.CommentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class UpdateCommentService implements UpdateCommentUseCase {
     private final CommentPort commentPort;
 
     @Override
+    @Transactional
     public Comment execute(final Long commentId, final CommentDto commentDto) {
         final Comment comment = commentPort.findById(commentId);
 

--- a/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 @Getter
 @AllArgsConstructor
 public class Comment {
+    private Long id;
     private String contents;
     private Long userId;
     private Long postId;
@@ -22,10 +23,19 @@ public class Comment {
                 postId
         );
     }
+    public Comment(final String contents, final Long userId, final Long postId) {
+        this.contents = contents;
+        this.userId = userId;
+        this.postId = postId;
+    }
 
     private void applyUpdateValidation(final Long userId, final Long postId) {
         if (!Objects.equals(this.userId, userId) || !Objects.equals(this.postId, postId)) {
             throw new UpdateCommentForbiddenException(0, "Edit comments forbidden.");
         }
+    }
+
+    public static Comment of(final Long id, final String contents, final Long userId, final Long postId) {
+        return new Comment(id, contents, userId, postId);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/domain/Comment.java
@@ -13,7 +13,7 @@ public class Comment {
     private Long userId;
     private Long postId;
 
-    public Comment update(Long userId, Long postId, String contents) {
+    public Comment update(final Long userId, final Long postId, final String contents) {
         applyUpdateValidation(userId, postId);
 
         return new Comment(
@@ -23,7 +23,7 @@ public class Comment {
         );
     }
 
-    private void applyUpdateValidation(Long userId, Long postId) {
+    private void applyUpdateValidation(final Long userId, final Long postId) {
         if (!Objects.equals(this.userId, userId) || !Objects.equals(this.postId, postId)) {
             throw new UpdateCommentForbiddenException(0, "Edit comments forbidden.");
         }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
@@ -1,6 +1,7 @@
 package com.depromeet.coquality.inner.comment.port.driven;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
+import java.util.List;
 
 public interface CommentPort {
     void save(final Comment comment);
@@ -8,4 +9,6 @@ public interface CommentPort {
     Comment findById(Long commentId);
 
     void delete(Long commentId, Long postId, Long userId);
+
+    List<Comment> fetch(Long postId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
@@ -1,6 +1,7 @@
 package com.depromeet.coquality.inner.comment.port.driven;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.vo.CommentResponse;
 import java.util.List;
 
 public interface CommentPort {
@@ -10,5 +11,5 @@ public interface CommentPort {
 
     void delete(Long commentId, Long postId, Long userId);
 
-    List<Comment> fetch(Long postId);
+    List<CommentResponse> fetch(Long postId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driven/CommentPort.java
@@ -6,4 +6,6 @@ public interface CommentPort {
     void save(final Comment comment);
 
     Comment findById(Long commentId);
+
+    void delete(Long commentId, Long postId, Long userId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/DeleteCommentUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/DeleteCommentUseCase.java
@@ -1,5 +1,5 @@
 package com.depromeet.coquality.inner.comment.port.driving;
 
 public interface DeleteCommentUseCase {
-    void execute();
+    void execute(Long commentId, Long postId, Long userId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/ReadCommentsUserCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/ReadCommentsUserCase.java
@@ -1,0 +1,8 @@
+package com.depromeet.coquality.inner.comment.port.driving;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import java.util.List;
+
+public interface ReadCommentsUserCase {
+    List<Comment> execute(Long postId);
+}

--- a/src/main/java/com/depromeet/coquality/inner/comment/port/driving/ReadCommentsUserCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/port/driving/ReadCommentsUserCase.java
@@ -1,8 +1,8 @@
 package com.depromeet.coquality.inner.comment.port.driving;
 
-import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.vo.CommentResponse;
 import java.util.List;
 
 public interface ReadCommentsUserCase {
-    List<Comment> execute(Long postId);
+    List<CommentResponse> execute(Long postId);
 }

--- a/src/main/java/com/depromeet/coquality/inner/comment/vo/CommentResponse.java
+++ b/src/main/java/com/depromeet/coquality/inner/comment/vo/CommentResponse.java
@@ -1,0 +1,23 @@
+package com.depromeet.coquality.inner.comment.vo;
+
+import java.time.LocalDateTime;
+
+public class CommentResponse {
+    private Long id;
+    private String contents;
+    private Long userId;
+    private Long postId;
+    private LocalDateTime createdAt;
+
+    private CommentResponse(final Long id, final String contents, final Long userId, final Long postId, final LocalDateTime createdAt) {
+        this.id = id;
+        this.contents = contents;
+        this.userId = userId;
+        this.postId = postId;
+        this.createdAt = createdAt;
+    }
+
+    public static CommentResponse of(final Long id, final String contents, final Long userId, final Long postId, final LocalDateTime createdAt){
+        return new CommentResponse(id, contents, userId, postId, createdAt);
+    }
+}

--- a/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
@@ -20,8 +20,11 @@ public enum CoQualityDomainExceptionCode {
     USER_ENTITY_IS_NULL(USER.code + 1, "User Entity is null"),
     User_SOCIAL_EMAIL_IS_NULL(USER.code + 2, "User's title is null"),
     USER_SOCIAL_ID_IS_NULL(USER.code + 3, "User's social id is null"),
-    USER_SOCIAL_NICKNAME_IS_NULL(USER.code + 4, "User's social nickname is null");
+    USER_SOCIAL_NICKNAME_IS_NULL(USER.code + 4, "User's social nickname is null"),
 
+    COMMENT(3000,"comment"),
+    COMMENT_ENTITY_IS_NULL(COMMENT.code + 1, "Comment Entity us null")
+        ;
     private final int code;
     private final String message;
 

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -3,16 +3,15 @@ package com.depromeet.coquality.outer.comment.adapter.driven.persistence;
 import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.exception.CommentNotFoundException;
 import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
+import com.depromeet.coquality.inner.comment.vo.CommentResponse;
 import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainExceptionCode;
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
 import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
 import com.depromeet.coquality.outer.common.exception.CoQualityOuterExceptionCode;
-import com.depromeet.coquality.outer.post.entity.PostEntity;
 import com.depromeet.coquality.outer.post.infrastructure.JpaPostRepository;
 import com.depromeet.coquality.outer.user.entity.UserEntity;
 import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -73,13 +72,13 @@ public class JpaCommentAdapter implements CommentPort {
     }
 
     @Override
-    public List<Comment> fetch(final Long postId) {
+    public List<CommentResponse> fetch(final Long postId) {
         jpaPostRepository.findById(postId)
                 .orElseThrow(CoQualityOuterExceptionCode.POST_ENTITY_IS_NULL::newInstance);
 
         List<CommentEntity> comments = jpaCommentRepository.findAllByPostId(postId);
         return comments.stream()
-                .map(CommentEntity::toComment)
+                .map(CommentEntity::toCommentResponse)
                 .toList();
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -6,6 +6,8 @@ import com.depromeet.coquality.inner.comment.port.driven.CommentPort;
 import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainExceptionCode;
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
 import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
+import com.depromeet.coquality.outer.common.exception.CoQualityOuterExceptionCode;
+import com.depromeet.coquality.outer.post.infrastructure.JpaPostRepository;
 import com.depromeet.coquality.outer.user.entity.UserEntity;
 import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,35 +22,50 @@ import static java.text.MessageFormat.format;
 public class JpaCommentAdapter implements CommentPort {
     private final JpaCommentRepository jpaCommentRepository;
     private final JpaUserRepository jpaUserRepository;
+    private final JpaPostRepository jpaPostRepository;
 
     @Override
-    public void save(Comment comment) {
+    public void save(final Comment comment) {
         final UserEntity user = jpaUserRepository.findById(comment.getUserId())
                 .orElseThrow(CoQualityDomainExceptionCode.USER_ENTITY_IS_NULL::newInstance);
 
         jpaCommentRepository.save(
                 CommentEntity.factory()
                         .contents(comment.getContents())
-                        .user(user)
+                        .userId(user.getId())
                         .postId(comment.getPostId())
                         .newInstance()
         );
     }
 
     @Override
-    public Comment findById(Long commentId) {
-        Optional<CommentEntity> optionalCommentEntity = jpaCommentRepository.findById(commentId);
+    public Comment findById(final Long commentId) {
+        final Optional<CommentEntity> optionalCommentEntity = jpaCommentRepository.findById(commentId);
 
         if (optionalCommentEntity.isPresent()) {
-            CommentEntity commentEntity = optionalCommentEntity.get();
+            final CommentEntity commentEntity = optionalCommentEntity.get();
             return new Comment(
                     commentEntity.getContents(),
-                    commentEntity.getUser().getId(),
+                    commentEntity.getUserId(),
                     commentEntity.getPostId()
             );
         }
 
         // TODO, change code or remove unnecessary code
         throw new CommentNotFoundException(0, format("Comment not found. id: {0}", commentId));
+    }
+
+    @Override
+    public void delete(final Long commentId, final Long postId, final Long userId) {
+        jpaUserRepository.findById(userId)
+                .orElseThrow(CoQualityDomainExceptionCode.USER_ENTITY_IS_NULL::newInstance);
+        jpaPostRepository.findById(postId)
+                .orElseThrow(CoQualityOuterExceptionCode.POST_ENTITY_IS_NULL::newInstance);
+        final CommentEntity commentEntity = jpaCommentRepository.findById(commentId)
+                .orElseThrow(CoQualityDomainExceptionCode.COMMENT_ENTITY_IS_NULL::newInstance);
+
+        //TODO 일단 하드 딜리트로
+        jpaCommentRepository.delete(commentEntity);
+
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driven/persistence/JpaCommentAdapter.java
@@ -7,9 +7,12 @@ import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainExce
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
 import com.depromeet.coquality.outer.comment.infrastructure.JpaCommentRepository;
 import com.depromeet.coquality.outer.common.exception.CoQualityOuterExceptionCode;
+import com.depromeet.coquality.outer.post.entity.PostEntity;
 import com.depromeet.coquality.outer.post.infrastructure.JpaPostRepository;
 import com.depromeet.coquality.outer.user.entity.UserEntity;
 import com.depromeet.coquality.outer.user.infrastructure.JpaUserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -67,5 +70,16 @@ public class JpaCommentAdapter implements CommentPort {
         //TODO 일단 하드 딜리트로
         jpaCommentRepository.delete(commentEntity);
 
+    }
+
+    @Override
+    public List<Comment> fetch(final Long postId) {
+        jpaPostRepository.findById(postId)
+                .orElseThrow(CoQualityOuterExceptionCode.POST_ENTITY_IS_NULL::newInstance);
+
+        List<CommentEntity> comments = jpaCommentRepository.findAllByPostId(postId);
+        return comments.stream()
+                .map(CommentEntity::toComment)
+                .toList();
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -8,10 +8,9 @@ import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.CreateCommentRequest;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.UpdateCommentRequest;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.response.CommentResponse;
-import com.depromeet.coquality.outer.comment.adapter.driving.web.response.CommentsResponse;
+import com.depromeet.coquality.outer.common.vo.ApiResponse;
 import com.depromeet.coquality.outer.interceptor.Auth;
 import com.depromeet.coquality.outer.resolver.UserId;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -61,8 +59,8 @@ public class CommentController {
     }
 
     @GetMapping("/{postId}")
-    public CommentsResponse getComments(@PathVariable final Long postId) {
-        final List<Comment> comments = readCommentsUserCase.execute(postId);
-        return new CommentsResponse(comments);
+    public ApiResponse getComments(@PathVariable final Long postId) {
+        final var comments = readCommentsUserCase.execute(postId);
+        return ApiResponse.success(comments);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -2,6 +2,7 @@ package com.depromeet.coquality.outer.comment.adapter.driving.web;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
+import com.depromeet.coquality.inner.comment.port.driving.DeleteCommentUseCase;
 import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.CreateCommentRequest;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.UpdateCommentRequest;
@@ -9,6 +10,7 @@ import com.depromeet.coquality.outer.comment.adapter.driving.web.response.Commen
 import com.depromeet.coquality.outer.interceptor.Auth;
 import com.depromeet.coquality.outer.resolver.UserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +27,7 @@ public class CommentController {
 
     private final CreateCommentUseCase createCommentUseCase;
     private final UpdateCommentUseCase updateCommentUseCase;
+    private final DeleteCommentUseCase deleteCommentUseCase;
 
     @PostMapping
     @Auth
@@ -40,4 +43,12 @@ public class CommentController {
         final Comment updatedComment = updateCommentUseCase.execute(commentId, updateCommentRequest.toCommentDto(userId));
         return CommentResponse.from(updatedComment);
     }
+    @DeleteMapping("/{postId}/{commentId}")
+    @Auth
+    public void deleteComment(@RequestParam final Long commentId,
+                              @RequestParam final Long postId,
+                              @UserId final Long userId){
+        deleteCommentUseCase.execute(commentId, postId, userId);
+    }
+    //TODO 댓글 조회 기능 추가.
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -41,7 +41,7 @@ public class CommentController {
                                          @Valid @RequestBody final UpdateCommentRequest updateCommentRequest,
                                          @UserId final Long userId) {
         final Comment updatedComment = updateCommentUseCase.execute(commentId, updateCommentRequest.toCommentDto(userId));
-        return CommentResponse.from(updatedComment);
+        return CommentResponse.from(commentId, updatedComment);
     }
     @DeleteMapping("/{postId}/{commentId}")
     @Auth

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/CommentController.java
@@ -3,14 +3,19 @@ package com.depromeet.coquality.outer.comment.adapter.driving.web;
 import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.inner.comment.port.driving.CreateCommentUseCase;
 import com.depromeet.coquality.inner.comment.port.driving.DeleteCommentUseCase;
+import com.depromeet.coquality.inner.comment.port.driving.ReadCommentsUserCase;
 import com.depromeet.coquality.inner.comment.port.driving.UpdateCommentUseCase;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.CreateCommentRequest;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.request.UpdateCommentRequest;
 import com.depromeet.coquality.outer.comment.adapter.driving.web.response.CommentResponse;
+import com.depromeet.coquality.outer.comment.adapter.driving.web.response.CommentsResponse;
 import com.depromeet.coquality.outer.interceptor.Auth;
 import com.depromeet.coquality.outer.resolver.UserId;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,27 +33,36 @@ public class CommentController {
     private final CreateCommentUseCase createCommentUseCase;
     private final UpdateCommentUseCase updateCommentUseCase;
     private final DeleteCommentUseCase deleteCommentUseCase;
+    private final ReadCommentsUserCase readCommentsUserCase;
 
     @PostMapping
     @Auth
-    public void createComment(@Valid @RequestBody final CreateCommentRequest createCommentRequest, @UserId final Long userId) {
+    public void createComment(@Valid @RequestBody final CreateCommentRequest createCommentRequest,
+                              @UserId final Long userId) {
         createCommentUseCase.execute(createCommentRequest.toCommentDto(userId));
     }
 
     @PutMapping("/{commentId}")
     @Auth
-    public CommentResponse updateComment(@RequestParam final Long commentId,
+    public CommentResponse updateComment(@PathVariable final Long commentId,
                                          @Valid @RequestBody final UpdateCommentRequest updateCommentRequest,
                                          @UserId final Long userId) {
-        final Comment updatedComment = updateCommentUseCase.execute(commentId, updateCommentRequest.toCommentDto(userId));
+        final Comment updatedComment = updateCommentUseCase.execute(commentId,
+                updateCommentRequest.toCommentDto(userId));
         return CommentResponse.from(commentId, updatedComment);
     }
+
     @DeleteMapping("/{postId}/{commentId}")
     @Auth
-    public void deleteComment(@RequestParam final Long commentId,
-                              @RequestParam final Long postId,
-                              @UserId final Long userId){
+    public void deleteComment(@PathVariable final Long commentId,
+                              @PathVariable final Long postId,
+                              @UserId final Long userId) {
         deleteCommentUseCase.execute(commentId, postId, userId);
     }
-    //TODO 댓글 조회 기능 추가.
+
+    @GetMapping("/{postId}")
+    public CommentsResponse getComments(@PathVariable final Long postId) {
+        final List<Comment> comments = readCommentsUserCase.execute(postId);
+        return new CommentsResponse(comments);
+    }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/CreateCommentRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/request/CreateCommentRequest.java
@@ -9,7 +9,7 @@ public record CreateCommentRequest(
         @NotNull Long postId,
         @NotBlank String contents
 ) {
-    public CommentDto toCommentDto(Long userId) {
+    public CommentDto toCommentDto(final Long userId) {
         return new CommentDto(
                 contents,
                 userId,

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentResponse.java
@@ -1,26 +1,20 @@
 package com.depromeet.coquality.outer.comment.adapter.driving.web.response;
 
+
 import com.depromeet.coquality.inner.comment.domain.Comment;
 
-import java.time.LocalDateTime;
-
 public record CommentResponse(
+        Long commentId,
         Long postId,
         Long userId,
-        Long commentId,
-        String contents,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        String contents
 ) {
-    public static CommentResponse from(Comment comment) {
-        // TODO, refactor commentId and time
+    public static CommentResponse from(final Long commentId, final Comment comment) {
         return new CommentResponse(
+                commentId,
                 comment.getPostId(),
                 comment.getUserId(),
-                1L,
-                comment.getContents(),
-                LocalDateTime.now(),
-                LocalDateTime.now()
+                comment.getContents()
         );
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentsResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentsResponse.java
@@ -1,0 +1,7 @@
+package com.depromeet.coquality.outer.comment.adapter.driving.web.response;
+
+import com.depromeet.coquality.inner.comment.domain.Comment;
+import java.util.List;
+
+public record CommentsResponse (List<Comment> comments) {
+}

--- a/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentsResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/adapter/driving/web/response/CommentsResponse.java
@@ -1,7 +1,0 @@
-package com.depromeet.coquality.outer.comment.adapter.driving.web.response;
-
-import com.depromeet.coquality.inner.comment.domain.Comment;
-import java.util.List;
-
-public record CommentsResponse (List<Comment> comments) {
-}

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -1,6 +1,7 @@
 package com.depromeet.coquality.outer.comment.entity;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
+import com.depromeet.coquality.inner.comment.vo.CommentResponse;
 import com.depromeet.coquality.outer.common.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,6 +40,15 @@ public class CommentEntity extends BaseEntity {
                 this.contents,
                 this.userId,
                 this.postId
+        );
+    }
+    public CommentResponse toCommentResponse(){
+        return CommentResponse.of(
+                getId(),
+                contents,
+                userId,
+                postId,
+                getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -1,13 +1,14 @@
 package com.depromeet.coquality.outer.comment.entity;
 
 import com.depromeet.coquality.outer.common.entity.BaseEntity;
-import com.depromeet.coquality.outer.user.entity.UserEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
@@ -16,23 +17,18 @@ import java.time.LocalDateTime;
 @Getter
 public class CommentEntity extends BaseEntity {
     public static final String TABLE_NAME = "comments";
-
     @Column(length = 200)
     private String contents;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private UserEntity user;
-
-    // TODO, mapped when postEntity is ready
+    private Long userId;
     private Long postId;
 
     private LocalDateTime deletedAt;
 
     @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
-    private CommentEntity(Long id, String contents, UserEntity user, Long postId) {
+    private CommentEntity(final Long id, final String contents, final Long userId, final Long postId) {
         this.contents = contents;
-        this.user = user;
+        this.userId = userId;
         this.postId = postId;
         this.deletedAt = null;
     }

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -2,9 +2,6 @@ package com.depromeet.coquality.outer.comment.entity;
 
 import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.outer.common.entity.BaseEntity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/entity/CommentEntity.java
@@ -1,6 +1,10 @@
 package com.depromeet.coquality.outer.comment.entity;
 
+import com.depromeet.coquality.inner.comment.domain.Comment;
 import com.depromeet.coquality.outer.common.entity.BaseEntity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,10 +30,18 @@ public class CommentEntity extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder(builderMethodName = "factory", buildMethodName = "newInstance")
-    private CommentEntity(final Long id, final String contents, final Long userId, final Long postId) {
+    private CommentEntity(final String contents, final Long userId, final Long postId) {
         this.contents = contents;
         this.userId = userId;
         this.postId = postId;
         this.deletedAt = null;
+    }
+    public Comment toComment(){
+        return Comment.of(
+                getId(),
+                this.contents,
+                this.userId,
+                this.postId
+        );
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/comment/infrastructure/JpaCommentRepository.java
+++ b/src/main/java/com/depromeet/coquality/outer/comment/infrastructure/JpaCommentRepository.java
@@ -1,7 +1,9 @@
 package com.depromeet.coquality.outer.comment.infrastructure;
 
 import com.depromeet.coquality.outer.comment.entity.CommentEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCommentRepository extends JpaRepository<CommentEntity, Long> {
+    List<CommentEntity> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/AuthController.java
@@ -31,13 +31,13 @@ public class AuthController {
         final SignUpUserUseCase signUpUserUseCase = signUpUserProvider.getSignUpService(request.getSocialType());
         final Long userId = signUpUserUseCase.execute(request.toInnerDto());
         final String token = jwtService.issuedToken(String.valueOf(userId), "USER", 60 * 60 * 24 * 30L);
-        return SignUpResponse.of(token, userId);
+        return SignUpResponse.of(token);
     }
     @PostMapping("/singin")
     public LoginResponse signIn(@Valid @RequestBody final LoginRequest request){
         final SignInUserUseCase signInUserUseCase = signInUserProvider.getSignUpService(request.getSocialType());
         final Long userId = signInUserUseCase.execute(request.toInnerDto());
         final String token = jwtService.issuedToken(String.valueOf(userId), "USER", 60 * 60 * 24 * 30L);
-        return LoginResponse.of(token, userId);
+        return LoginResponse.of(token);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/LoginResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/LoginResponse.java
@@ -5,14 +5,12 @@ import lombok.Getter;
 @Getter
 public class LoginResponse {
     private String token;
-    private Long userId;
 
-    private LoginResponse(final String token, final Long userId) {
+    private LoginResponse(final String token) {
         this.token = token;
-        this.userId = userId;
     }
 
-    public static LoginResponse of(final String token, final Long userId){
-        return new LoginResponse(token,userId);
+    public static LoginResponse of(final String token){
+        return new LoginResponse(token);
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/SignUpResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/user/adapter/driving/web/dto/response/SignUpResponse.java
@@ -5,14 +5,12 @@ import lombok.Getter;
 @Getter
 public class SignUpResponse {
     private String token;
-    private Long userId;
 
-    private SignUpResponse(final String token, final Long userId) {
+    private SignUpResponse(final String token) {
         this.token = token;
-        this.userId = userId;
     }
 
-    public static SignUpResponse of(final String token, final Long userId){
-        return new SignUpResponse(token,userId);
+    public static SignUpResponse of(final String token){
+        return new SignUpResponse(token);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   profiles:
     default: prod
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher


### PR DESCRIPTION
## 개요
close #44 
댓글 조회하기 기능

## 작업사항
- 댓글 조회하기 기능 API 구현
- 댓글 엔티티 수정
- 댓글 도메인 수정 id 필드 추가

## 변경로직
- 댓글의 id도 보내줘야 해서 id 필드를 추가했어요.
