### PR TITLE
글 수정 API 정책 수정 및 고도화

### DIFF
--- a/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
@@ -17,7 +17,8 @@ public enum CoQualityDomainExceptionCode {
     POST_STATUS_CODE_IS_NULL(POST.code + 10, "Post's status code is null"),
     POST_THUMBNAIL_NOT_VALID(POST.code + 11, "Post's thumbnail is not valid"),
     ILLEGAL_POST_STATUS(POST.code + 12, "Post's status should not be status (%s)"),
-
+    POST_MODIFIER_ID_IS_NULL(POST.code + 13, "Post's modifier's id is null"),
+    POST_PERMISSION(POST.code + 14, "Do not have permission to edit the post"),
 
     USER(2000, "user"),
     USER_ENTITY_IS_NULL(USER.code + 1, "User Entity is null"),

--- a/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
@@ -16,6 +16,8 @@ public enum CoQualityDomainExceptionCode {
     POST_VIEWS_MIN_SIZE_VIOLATE(POST.code + 9, "Posts's view's value is smaller than %s"),
     POST_STATUS_CODE_IS_NULL(POST.code + 10, "Post's status code is null"),
     POST_THUMBNAIL_NOT_VALID(POST.code + 11, "Post's thumbnail is not valid"),
+    ILLEGAL_POST_STATUS(POST.code + 12, "Post's status should not be status (%s)"),
+
 
     USER(2000, "user"),
     USER_ENTITY_IS_NULL(USER.code + 1, "User Entity is null"),
@@ -23,9 +25,8 @@ public enum CoQualityDomainExceptionCode {
     USER_SOCIAL_ID_IS_NULL(USER.code + 3, "User's social id is null"),
     USER_SOCIAL_NICKNAME_IS_NULL(USER.code + 4, "User's social nickname is null"),
 
-    COMMENT(3000,"comment"),
-    COMMENT_ENTITY_IS_NULL(COMMENT.code + 1, "Comment Entity us null")
-        ;
+    COMMENT(3000, "comment"),
+    COMMENT_ENTITY_IS_NULL(COMMENT.code + 1, "Comment Entity us null");
     private final int code;
     private final String message;
 

--- a/src/main/java/com/depromeet/coquality/inner/post/application/service/ModifyPostService.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/application/service/ModifyPostService.java
@@ -15,15 +15,18 @@ public class ModifyPostService implements ModifyPostUseCase {
 
     @Transactional
     @Override
-    public void execute(final Long id, final ModifyPostCommand modifyPostCommand) {
+    public void execute(Long userId, final Long id,
+        final ModifyPostCommand modifyPostCommand) {
         final var post = postPort.fetchOne(id);
         post
-            .modifyTitle(modifyPostCommand.title().orElseGet(post::getTitle))
-            .modifyContents(modifyPostCommand.contents().orElseGet(post::getContents))
-            .modifySummary(modifyPostCommand.summary().orElseGet(post::getSummary))
-            .modifyPostStatusCode(modifyPostCommand.postStatus().orElseGet(post::getPostStatusCode))
-            .modifyThumbnail(modifyPostCommand.thumbnail().orElseGet(post::getThumbnail))
+            .modifyTitle(userId, modifyPostCommand.title().orElseGet(post::getTitle))
+            .modifyContents(userId, modifyPostCommand.contents().orElseGet(post::getContents))
+            .modifySummary(userId, modifyPostCommand.summary().orElseGet(post::getSummary))
+            .modifyPostStatusCode(userId,
+                modifyPostCommand.postStatus().orElseGet(post::getPostStatusCode))
+            .modifyThumbnail(userId, modifyPostCommand.thumbnail().orElseGet(post::getThumbnail))
             .modifyPrimaryCategory(
+                userId,
                 modifyPostCommand.primaryPostCategoryCode().orElseGet(post::getPrimaryCategory)
             )
         ;

--- a/src/main/java/com/depromeet/coquality/inner/post/application/service/ModifyPostService.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/application/service/ModifyPostService.java
@@ -1,8 +1,8 @@
 package com.depromeet.coquality.inner.post.application.service;
 
-import com.depromeet.coquality.inner.post.domain.Post;
 import com.depromeet.coquality.inner.post.port.driven.PostPort;
 import com.depromeet.coquality.inner.post.port.driving.ModifyPostUseCase;
+import com.depromeet.coquality.inner.post.vo.ModifyPostCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +15,18 @@ public class ModifyPostService implements ModifyPostUseCase {
 
     @Transactional
     @Override
-    public void execute(final Long id, final Post post) {
-        postPort.update(id, post);
+    public void execute(final Long id, final ModifyPostCommand modifyPostCommand) {
+        final var post = postPort.fetchOne(id);
+        post
+            .modifyTitle(modifyPostCommand.title().orElseGet(post::getTitle))
+            .modifyContents(modifyPostCommand.contents().orElseGet(post::getContents))
+            .modifySummary(modifyPostCommand.summary().orElseGet(post::getSummary))
+            .modifyPostStatusCode(modifyPostCommand.postStatus().orElseGet(post::getPostStatusCode))
+            .modifyThumbnail(modifyPostCommand.thumbnail().orElseGet(post::getThumbnail))
+            .modifyPrimaryCategory(
+                modifyPostCommand.primaryPostCategoryCode().orElseGet(post::getPrimaryCategory)
+            )
+        ;
+        postPort.update(post);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostDetailService.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostDetailService.java
@@ -16,6 +16,6 @@ public class ReadPostDetailService implements ReadPostDetailUseCase {
     @Transactional
     @Override
     public PostDetailResponse execute(final Long id) {
-        return postPort.fetchOne(id);
+        return postPort.readOne(id);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostDetailService.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostDetailService.java
@@ -15,7 +15,7 @@ public class ReadPostDetailService implements ReadPostDetailUseCase {
 
     @Transactional
     @Override
-    public PostDetailResponse execute(final Long id) {
-        return postPort.readOne(id);
+    public PostDetailResponse execute(final Long userId, final Long id) {
+        return postPort.readOne(userId, id);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostsService.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/application/service/ReadPostsService.java
@@ -18,6 +18,6 @@ public class ReadPostsService implements ReadPostsUseCase {
     @Transactional
     @Override
     public List<PostResponse> execute(PostsReadInfo postsReadInfo) {
-        return postPort.fetch(postsReadInfo);
+        return postPort.readPosts(postsReadInfo);
     }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/Post.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/Post.java
@@ -91,33 +91,34 @@ public class Post {
             .newInstance();
     }
 
-    public Post modifyTitle(String title) {
+    public Post modifyTitle(Long userId, String title) {
+        PostValidationPolicy.validateUser(this.userId, userId);
         PostValidationPolicy.validateTitle(title);
         this.title = title;
         return this;
     }
 
-    public Post modifyContents(String contents) {
+    public Post modifyContents(Long userId, String contents) {
         PostValidationPolicy.validateContents(contents);
         this.contents = contents;
         return this;
     }
 
-    public Post modifyThumbnail(URI thumbnail) {
+    public Post modifyThumbnail(Long userId, URI thumbnail) {
         PostValidationPolicy.validateThumbnail(thumbnail);
         this.thumbnail = thumbnail;
         return this;
     }
 
     public Post modifyPrimaryCategory(
-        PrimaryPostCategoryCode primaryCategory) {
+        Long userId, PrimaryPostCategoryCode primaryCategory) {
         PostValidationPolicy.validatePrimaryCategory(primaryCategory);
         this.primaryCategory = primaryCategory;
         return this;
     }
 
     public Post modifyPostStatusCode(
-        PostStatusCode postStatusCode) {
+        Long userId, PostStatusCode postStatusCode) {
         PostValidationPolicy.validatePostStatusCodeModification(
             this.postStatusCode,
             postStatusCode
@@ -126,7 +127,7 @@ public class Post {
         return this;
     }
 
-    public Post modifySummary(String summary) {
+    public Post modifySummary(Long userId, String summary) {
         PostValidationPolicy.validateSummary(summary);
         this.summary = summary;
         return this;

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/Post.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/Post.java
@@ -91,4 +91,44 @@ public class Post {
             .newInstance();
     }
 
+    public Post modifyTitle(String title) {
+        PostValidationPolicy.validateTitle(title);
+        this.title = title;
+        return this;
+    }
+
+    public Post modifyContents(String contents) {
+        PostValidationPolicy.validateContents(contents);
+        this.contents = contents;
+        return this;
+    }
+
+    public Post modifyThumbnail(URI thumbnail) {
+        PostValidationPolicy.validateThumbnail(thumbnail);
+        this.thumbnail = thumbnail;
+        return this;
+    }
+
+    public Post modifyPrimaryCategory(
+        PrimaryPostCategoryCode primaryCategory) {
+        PostValidationPolicy.validatePrimaryCategory(primaryCategory);
+        this.primaryCategory = primaryCategory;
+        return this;
+    }
+
+    public Post modifyPostStatusCode(
+        PostStatusCode postStatusCode) {
+        PostValidationPolicy.validatePostStatusCodeModification(
+            this.postStatusCode,
+            postStatusCode
+        );
+        this.postStatusCode = postStatusCode;
+        return this;
+    }
+
+    public Post modifySummary(String summary) {
+        PostValidationPolicy.validateSummary(summary);
+        this.summary = summary;
+        return this;
+    }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/constant/PostConstant.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/constant/PostConstant.java
@@ -1,8 +1,0 @@
-package com.depromeet.coquality.inner.post.domain.constant;
-
-public final class PostConstant {
-
-    public static final String POST_WRITE = "글쓰기";
-    public static final String INVALID_TITLE = "잘못된 제목입니다.";
-
-}

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
@@ -121,4 +121,13 @@ public final class PostValidationPolicy {
         }
     }
 
+    public static void validateUser(Long authId, Long userId) {
+        if (userId == null) {
+            throw CoQualityDomainExceptionCode.POST_MODIFIER_ID_IS_NULL.newInstance();
+        }
+
+        if (!userId.equals(authId)) {
+            throw CoQualityDomainExceptionCode.POST_PERMISSION.newInstance();
+        }
+    }
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
@@ -75,10 +75,27 @@ public final class PostValidationPolicy {
         }
     }
 
+    public static void validatePostStatusCodeModification(
+        final PostStatusCode prevStatus,
+        final PostStatusCode currentStatus
+    ) {
+        if (prevStatus == null || currentStatus == null) {
+            throw CoQualityDomainExceptionCode.POST_STATUS_CODE_IS_NULL.newInstance();
+        }
+
+        if (prevStatus == PostStatusCode.DELETED || currentStatus == PostStatusCode.DELETED) {
+            throw CoQualityDomainExceptionCode.ILLEGAL_POST_STATUS.newInstance(
+                PostStatusCode.DELETED);
+        }
+
+
+    }
+
     public static void validateSummary(final String summary) {
         if (summary == null) {
             throw CoQualityDomainExceptionCode.POST_SUMMARY_IS_NULL.newInstance();
         }
+
     }
 
     public static void validateViews(final Long views) {
@@ -103,4 +120,5 @@ public final class PostValidationPolicy {
             throw CoQualityDomainExceptionCode.POST_THUMBNAIL_NOT_VALID.newInstance(e);
         }
     }
+
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/port/driven/PostPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/port/driven/PostPort.java
@@ -10,12 +10,14 @@ public interface PostPort {
 
     void create(final Post post);
 
-    PostDetailResponse fetchOne(final Long id);
+    PostDetailResponse readOne(final Long id);
 
-    List<PostResponse> fetch(PostsReadInfo postsReadInfo);
+    List<PostResponse> readPosts(PostsReadInfo postsReadInfo);
+
+    Post fetchOne(final Long id);
 
     void delete(final Long id);
 
-    void update(Long id, final Post post);
+    void update(final Post post);
 
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/port/driven/PostPort.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/port/driven/PostPort.java
@@ -10,7 +10,7 @@ public interface PostPort {
 
     void create(final Post post);
 
-    PostDetailResponse readOne(final Long id);
+    PostDetailResponse readOne(Long userId, final Long id);
 
     List<PostResponse> readPosts(PostsReadInfo postsReadInfo);
 

--- a/src/main/java/com/depromeet/coquality/inner/post/port/driving/ModifyPostUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/port/driving/ModifyPostUseCase.java
@@ -1,8 +1,8 @@
 package com.depromeet.coquality.inner.post.port.driving;
 
-import com.depromeet.coquality.inner.post.domain.Post;
+import com.depromeet.coquality.inner.post.vo.ModifyPostCommand;
 
 public interface ModifyPostUseCase {
 
-    void execute(final Long id, Post post);
+    void execute(Long id, ModifyPostCommand post);
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/port/driving/ModifyPostUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/port/driving/ModifyPostUseCase.java
@@ -4,5 +4,5 @@ import com.depromeet.coquality.inner.post.vo.ModifyPostCommand;
 
 public interface ModifyPostUseCase {
 
-    void execute(Long id, ModifyPostCommand post);
+    void execute(Long userId, Long id, ModifyPostCommand post);
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/port/driving/ReadPostDetailUseCase.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/port/driving/ReadPostDetailUseCase.java
@@ -4,5 +4,5 @@ import com.depromeet.coquality.inner.post.vo.PostDetailResponse;
 
 public interface ReadPostDetailUseCase {
 
-    PostDetailResponse execute(final Long id);
+    PostDetailResponse execute(final Long userId, final Long id);
 }

--- a/src/main/java/com/depromeet/coquality/inner/post/vo/ModifyPostCommand.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/vo/ModifyPostCommand.java
@@ -1,0 +1,34 @@
+package com.depromeet.coquality.inner.post.vo;
+
+import com.depromeet.coquality.inner.post.domain.code.PostStatusCode;
+import com.depromeet.coquality.inner.post.domain.code.PrimaryPostCategoryCode;
+import java.net.URI;
+import java.util.Optional;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record ModifyPostCommand(Optional<@NotBlank String> title,
+                                Optional<@NotBlank String> contents,
+                                Optional<URI> thumbnail,
+                                Optional<@NotNull PrimaryPostCategoryCode> primaryPostCategoryCode,
+                                Optional<@NotNull PostStatusCode> postStatus,
+                                Optional<@NotNull String> summary) {
+
+    public static ModifyPostCommand of(
+        Optional<String> title,
+        Optional<String> contents,
+        Optional<URI> thumbnail,
+        Optional<PrimaryPostCategoryCode> primaryPostCategoryCode,
+        Optional<PostStatusCode> postStatus,
+        Optional<String> summary
+    ) {
+        return new ModifyPostCommand(
+            title,
+            contents,
+            thumbnail,
+            primaryPostCategoryCode,
+            postStatus,
+            summary
+        );
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driven/persistence/JpaPostAdapter.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driven/persistence/JpaPostAdapter.java
@@ -29,12 +29,12 @@ public class JpaPostAdapter implements PostPort {
     }
 
     @Override
-    public PostDetailResponse readOne(Long id) {
+    public PostDetailResponse readOne(Long userId, Long id) {
         final var postEntity = jpaPostRepository.findByIdAndPostStatusCodeNotLike(id,
                 PostStatusCode.DELETED)
             .orElseThrow(() -> CoQualityOuterExceptionCode.POST_ENTITY_IS_NULL.newInstance(id));
 
-        if (!postEntity.getId().equals(id)) {
+        if (!postEntity.getUserId().equals(userId)) {
             postEntity.increaseViews(1L);
         }
         jpaPostRepository.save(postEntity);

--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
@@ -63,9 +63,9 @@ public class PostController {
             primaryCategory,
             PostStatusCode.POST_ISSUED
         );
-        final var posts = readPostsUseCase.execute(postReadInfo);
+        final var postResponses = readPostsUseCase.execute(postReadInfo);
 
-        return ApiResponse.success(posts);
+        return ApiResponse.success(postResponses);
     }
 
     @Auth
@@ -75,17 +75,15 @@ public class PostController {
         @RequestParam PostSortCode sort
     ) {
         final var postsReadInfo = PostsReadInfo.of(tokenId, sort, PostStatusCode.POST_NOT_DELETED);
-        final var posts = readPostsUseCase.execute(postsReadInfo);
+        final var postResponses = readPostsUseCase.execute(postsReadInfo);
 
-        return ApiResponse.success(posts);
+        return ApiResponse.success(postResponses);
     }
 
     @PutMapping("/{id}")
     public void modifyPost(@PathVariable final Long id,
         @RequestBody ModifyPostRequest modifyPostRequest) {
-        final var post = modifyPostRequest.toPost(id);
-
-        modifyPostUseCase.execute(id, post);
+        modifyPostUseCase.execute(id, modifyPostRequest.toModifyPostCommand());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
@@ -47,9 +47,12 @@ public class PostController {
         issuePostUseCase.execute(post);
     }
 
+    @Auth
     @GetMapping("/{id}")
-    public ApiResponse readPostDetail(@PathVariable final Long id) {
-        final var post = readPostDetailUseCase.execute(id);
+    public ApiResponse readPostDetail(
+        @UserId final Long userId,
+        @PathVariable final Long id) {
+        final var post = readPostDetailUseCase.execute(userId, id);
         return ApiResponse.success(post);
     }
 

--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
@@ -74,19 +74,22 @@ public class PostController {
     @Auth
     @GetMapping("/users/my")
     public ApiResponse readMyPosts(
-        @UserId Long tokenId,
+        @UserId Long userId,
         @RequestParam PostSortCode sort
     ) {
-        final var postsReadInfo = PostsReadInfo.of(tokenId, sort, PostStatusCode.POST_NOT_DELETED);
+        final var postsReadInfo = PostsReadInfo.of(userId, sort, PostStatusCode.POST_NOT_DELETED);
         final var postResponses = readPostsUseCase.execute(postsReadInfo);
 
         return ApiResponse.success(postResponses);
     }
 
+    @Auth
     @PutMapping("/{id}")
-    public void modifyPost(@PathVariable final Long id,
+    public void modifyPost(
+        @UserId Long userId,
+        @PathVariable final Long id,
         @RequestBody ModifyPostRequest modifyPostRequest) {
-        modifyPostUseCase.execute(id, modifyPostRequest.toModifyPostCommand());
+        modifyPostUseCase.execute(userId, id, modifyPostRequest.toModifyPostCommand());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/request/ModifyPostRequest.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/request/ModifyPostRequest.java
@@ -1,33 +1,30 @@
 package com.depromeet.coquality.outer.post.adapter.driving.web.request;
 
-import com.depromeet.coquality.inner.post.domain.Post;
 import com.depromeet.coquality.inner.post.domain.code.PostStatusCode;
 import com.depromeet.coquality.inner.post.domain.code.PrimaryPostCategoryCode;
+import com.depromeet.coquality.inner.post.vo.ModifyPostCommand;
 import java.net.URI;
+import java.util.Optional;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 public record ModifyPostRequest(
-    @NotBlank String title,
-    @NotBlank String contents,
-    URI thumbnail,
-    @NotNull PrimaryPostCategoryCode primaryPostCategoryCode,
-    @NotNull PostStatusCode postStatus,
-    @NotNull String summary,
-    @NotNull Long views
+    Optional<@NotBlank String> title,
+    Optional<@NotBlank String> contents,
+    Optional<URI> thumbnail,
+    Optional<@NotNull PrimaryPostCategoryCode> primaryPostCategoryCode,
+    Optional<@NotNull PostStatusCode> postStatus,
+    Optional<@NotNull String> summary
 ) {
 
-    public Post toPost(Long id) {
-        return Post.of(
-            id,
-            null, // TODO 임시로 null 처리
+    public ModifyPostCommand toModifyPostCommand() {
+        return ModifyPostCommand.of(
             title,
             contents,
             thumbnail,
             primaryPostCategoryCode,
             postStatus,
-            summary,
-            views
+            summary
         );
     }
 }

--- a/src/main/java/com/depromeet/coquality/outer/post/entity/PostEntity.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/entity/PostEntity.java
@@ -57,9 +57,7 @@ public class PostEntity extends BaseEntity {
     }
 
     public static PostEntity from(Post post) {
-        final var thumbnail = post.getThumbnail() == null ?
-            null :
-            String.valueOf(post.getThumbnail());
+        final var thumbnail = convertURIToString(post.getThumbnail());
 
         return PostEntity.factory()
             .title(post.getTitle())
@@ -78,7 +76,7 @@ public class PostEntity extends BaseEntity {
             getId(),
             userId,
             title,
-            convertURI(thumbnail),
+            convertStringToURI(thumbnail),
             primaryCategory,
             postStatusCode,
             summary,
@@ -94,7 +92,7 @@ public class PostEntity extends BaseEntity {
             userId,
             title,
             contents,
-            convertURI(thumbnail),
+            convertStringToURI(thumbnail),
             primaryCategory,
             postStatusCode,
             summary,
@@ -109,7 +107,7 @@ public class PostEntity extends BaseEntity {
             userId,
             title,
             contents,
-            convertURI(thumbnail),
+            convertStringToURI(thumbnail),
             primaryCategory,
             postStatusCode,
             summary,
@@ -123,6 +121,10 @@ public class PostEntity extends BaseEntity {
 
     public void modifyContents(@NonNull String contents) {
         this.contents = contents;
+    }
+
+    public void modifyThumbnail(URI thumbnail) {
+        this.thumbnail = convertURIToString(thumbnail);
     }
 
     public void changePrimaryPostCategoryCode(
@@ -142,7 +144,11 @@ public class PostEntity extends BaseEntity {
         views += count;
     }
 
-    private URI convertURI(String uri) {
-        return uri == null ? null : URI.create(uri);
+    private static URI convertStringToURI(String str) {
+        return str == null ? null : URI.create(str);
+    }
+
+    private static String convertURIToString(URI uri) {
+        return uri == null ? null : String.valueOf(uri);
     }
 }


### PR DESCRIPTION
## 개요
close #51 

## 작업사항
- 글 수정하기 API를 기존에 존재하는 postEntity를 가지고 수정하도록 기능 변경
- 글 수정 validation 정책 추가
