### PR TITLE
이미지 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     //query dsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+    //aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
@@ -9,7 +9,7 @@ public enum CoQualityDomainExceptionCode {
     POST_TITLE_MIN_LENGTH_VIOLATE(POST.code + 2, "Post title's length is shorter than %s"),
     POST_TITLE_MAX_LENGTH_VIOLATE(POST.code + 3, "Post title's length is longer than %s"),
     POST_CONTENTS_IS_NULL(POST.code + 4, "Post's contents should not be null"),
-    POST_CONTENTS_MAX_LENGTH_VIOLATE(POST.code + 5, "Post title's length is longer than %s"),
+    POST_CONTENTS_MAX_LENGTH_VIOLATE(POST.code + 5, "Post content's length is longer than %s"),
     POST_PRIMARY_CATEGORY_IS_NULL(POST.code + 6, "Post's primary category should not be null"),
     POST_SUMMARY_IS_NULL(POST.code + 7, "Post's summary should not be null"),
     POST_VIEWS_IS_NULL(POST.code + 8, "Post's views is null"),

--- a/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
+++ b/src/main/java/com/depromeet/coquality/inner/common/domain/exception/CoQualityDomainExceptionCode.java
@@ -19,7 +19,7 @@ public enum CoQualityDomainExceptionCode {
     ILLEGAL_POST_STATUS(POST.code + 12, "Post's status should not be status (%s)"),
     POST_MODIFIER_ID_IS_NULL(POST.code + 13, "Post's modifier's id is null"),
     POST_PERMISSION(POST.code + 14, "Do not have permission to edit the post"),
-    POST_ENTITY_IS_NULL(POST.code + 15, "post entity is null" ),
+    POST_ENTITY_IS_NULL(POST.code + 15, "post entity is null"),
 
     USER(2000, "user"),
     USER_ENTITY_IS_NULL(USER.code + 1, "User Entity is null"),
@@ -34,14 +34,16 @@ public enum CoQualityDomainExceptionCode {
 
     FOLLOW(4000, "follow"),
     FOLLOW_ENTITY_IS_DUPLICATE(FOLLOW.code + 1, "follow entity is duplicate"),
-    FOLLOW_ENTITY_IS_NULL(FOLLOW.code + 2, "follow entity is null" ),
+    FOLLOW_ENTITY_IS_NULL(FOLLOW.code + 2, "follow entity is null"),
     FOLLOW_TO_USER_IS_NULL(FOLLOW.code + 3, "follow Target is null"),
 
     BOOKMARK(5000, "bookmark"),
     BOOKMARK_USERID_IS_NULL(BOOKMARK.code + 1, "bookmark userId is null"),
     BOOKMARK_POSTID_IS_NULL(BOOKMARK.code + 2, "bookmark postId is null"),
-    BOOKMARK_ENTITY_IS_NULL(BOOKMARK.code + 3, "bookmark entity is null" )
-    ;
+    BOOKMARK_ENTITY_IS_NULL(BOOKMARK.code + 3, "bookmark entity is null"),
+
+    IMAGE(6000, "image %s"),
+    IMAGE_IS_NULL(IMAGE.code + 1, "image is null");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
+++ b/src/main/java/com/depromeet/coquality/inner/post/domain/policy/validation/PostValidationPolicy.java
@@ -12,7 +12,7 @@ public final class PostValidationPolicy {
     private static final int TITLE_MIN_LENGTH = 1;
     private static final int TITLE_MAX_LENGTH = 100;
 
-    private static final int CONTENTS_MAX_LENGTH = 2000; // 임의 설정
+    private static final int CONTENTS_MAX_LENGTH = 5000; // 임의 설정
 
     private static final int VIEWS_MIN_SIZE = 0;
 

--- a/src/main/java/com/depromeet/coquality/outer/common/config/S3Config.java
+++ b/src/main/java/com/depromeet/coquality/outer/common/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.depromeet.coquality.outer.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(region)
+            .build();
+    }
+}

--- a/src/main/java/com/depromeet/coquality/outer/image/adapter/driving/web/ImageController.java
+++ b/src/main/java/com/depromeet/coquality/outer/image/adapter/driving/web/ImageController.java
@@ -1,0 +1,67 @@
+package com.depromeet.coquality.outer.image.adapter.driving.web;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.depromeet.coquality.inner.common.domain.exception.CoQualityDomainExceptionCode;
+import com.depromeet.coquality.outer.common.vo.ApiResponse;
+import com.depromeet.coquality.outer.image.adapter.driving.web.response.ImageUploadResponse;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ImageUploadResponse> uploadImage(@RequestParam MultipartFile image) {
+        final var imageFile = convert(image).orElseThrow(
+            CoQualityDomainExceptionCode.IMAGE_IS_NULL::newInstance);
+
+        final var url = upload(imageFile);
+        final var response = new ImageUploadResponse(url, imageFile.getName());
+        
+        return ApiResponse.success(response);
+    }
+
+    private String upload(File uploadFile) {
+        final var fileName = String.format("images/%s", UUID.randomUUID());
+
+        amazonS3Client.putObject(
+            new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+
+    }
+
+    private Optional<File> convert(MultipartFile file) {
+        File convertedFile = new File(Objects.requireNonNull(file.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        } catch (Exception e) {
+            throw CoQualityDomainExceptionCode.IMAGE.newInstance(e.getCause(),
+                e.getMessage());
+        }
+        return Optional.of(convertedFile);
+    }
+
+}

--- a/src/main/java/com/depromeet/coquality/outer/image/adapter/driving/web/response/ImageUploadResponse.java
+++ b/src/main/java/com/depromeet/coquality/outer/image/adapter/driving/web/response/ImageUploadResponse.java
@@ -1,0 +1,10 @@
+package com.depromeet.coquality.outer.image.adapter.driving.web.response;
+
+import lombok.NonNull;
+
+public record ImageUploadResponse(
+    @NonNull String url,
+    @NonNull String originalFileName
+) {
+
+}


### PR DESCRIPTION
## 개요
close #50 
이미지 업로드 API를 구현하였습니다.

## 작업사항
- S3 관련 config 추가
    - application.yml
    - gradle
    - @Configuration
- API 구현

굳이 레이어를 나눌 필요 없는 기능인 것 같아서, 컨트롤러에 로직을 다 넣어버렸습니다 ㅎ
+ 추가적으로 상민님이 컨텐츠 길이 관련 문의를 주셔서, 일단 5000자로 임의 조정 했습니다.