### PR TITLE
특정 사용자 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
+++ b/src/main/java/com/depromeet/coquality/outer/post/adapter/driving/web/PostController.java
@@ -89,7 +89,19 @@ public class PostController {
     }
 
     @Auth
-    @GetMapping("/users/my")
+    @GetMapping("/users/{userId}")
+    public ApiResponse<List<PostResponse>> readUsersPost(
+        @PathVariable Long userId,
+        @RequestParam PostSortCode sort
+    ) {
+        final var postsReadInfo = PostsReadInfo.of(userId, sort, PostStatusCode.POST_ISSUED);
+        final var postResponses = readPostsUseCase.execute(postsReadInfo);
+
+        return ApiResponse.success(postResponses);
+    }
+
+    @Auth
+    @GetMapping("/my")
     public ApiResponse<List<PostResponse>> readMyPosts(
         @UserId Long userId,
         @RequestParam PostSortCode sort


### PR DESCRIPTION
## 개요
특정 사용자의 게시글을 조회하는 API를 추가합니다.

## 작업사항
- 내 글 조회 API endpoint 수정
- 다른 사용자 글 조회 API endpoint 생성